### PR TITLE
Add Warfly map source and fix missing layer type issue | Добавление Warfly карты и прочие незначительные изменения

### DIFF
--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -330,6 +330,19 @@ define([
                         limitZoom: 19,
                         attribution: '&copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                         maxAfter: 'mapnik'
+                    },
+                    {
+                        id: 'warfly',
+                        desc: 'АэрофотоВОВ',
+                        selected: ko.observable(false),
+                        obj: new L.TileLayer('https://17200.selcdn.ru/AerialWWII/Z{z}/{y}/{x}.jpg', {
+                            attribution: 'Аэрофотосъёмка Второй Мировой Войны <a href="http://warfly.ru/about">warfly.ru</a> (доступна для отдельных городов)',
+                            updateWhenIdle: false,
+                            minZoom:9,
+                            maxNativeZoom: 18
+                        }),
+                        maxZoom: 18,
+                        minZoom: 9
                     }
                 ])
             });

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -276,24 +276,6 @@ define([
                             selected: ko.observable(false),
                             params: 'hybrid',
                             maxZoom: 19
-                        },
-                        {
-                            id: 'pub',
-                            desc: 'Народная',
-                            selected: ko.observable(false),
-                            params: 'publicMap',
-                            maxZoom: 20,
-                            limitZoom: 19,
-                            //maxAfter: 'google.scheme'
-                        },
-                        {
-                            id: 'pubhyb',
-                            desc: 'Народн. гибр.',
-                            selected: ko.observable(false),
-                            params: 'publicMapHybrid',
-                            maxZoom: 20,
-                            limitZoom: 19,
-                            //maxAfter: 'google.scheme'
                         }
                     ])
                 });


### PR DESCRIPTION
The patch-set contains the following:
* Add warfly.ru as new map type. This is useful for localising places that no longer exists or have been significantly changed since WWII. The map is not complete, disclaimer has been added to attribution. For more details, please refer to http://warfly.ru/about/
* Fix the blank screen issue resulting in modified (or removed) layer type id (see https://github.com/PastVu/pastvu/pull/190#issuecomment-715821379). The cause of the issue was in the attempt to use default type with non-default system. The amended logic is to use default system/type pair in case of undefined layer type.
* Re-apply reverted patch https://github.com/PastVu/pastvu/commit/96c023ed4e92912a150e82e9872e3957b20c87d2 (tested locally after above fix being applied).