### PR TITLE
Add Mailcatcher container to docker-compose file and example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ docker-compose up
 ```
 
 Navigate to http://localhost:3000 and login with the default user `admin`/`admin`!
+
+Mailcatcher web interface is listening on http://localhost:1080 to view emails which app has sent out.

--- a/config/local.config.js.docker-example
+++ b/config/local.config.js.docker-example
@@ -30,17 +30,10 @@ module.exports = function(config, appRequire) {
         redis: {
             host: 'redis',
         },
-
-        // In development you should create a test account at https://ethereal.email, so email will not be sent to the real users
-
         mail: {
             type: 'SMTP',
-            host: 'smtp.ethereal.email',
-            port: 587,
-            auth: {
-                user: '',
-                pass: '',
-            },
+            host: 'mailcatcher',
+            port: 1025,
         },
     });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,13 @@ services:
       - sitemap:/sitemap
     command: npm run sitemap
 
+  mailcatcher:
+    image: sj26/mailcatcher
+    expose:
+     - "1025"
+    ports:
+     - "1080:1080"
+
 volumes:
   store:
   sitemap:


### PR DESCRIPTION
In docker-based local deployment for development, this allows redirecting emails to Mailcather service and inspecting them by accessing Mailcatcher front-end at http://localhost:1080. This simplifies email testing approach (i.e. no need to use an external service).

![mcatcher](https://user-images.githubusercontent.com/329780/97642712-c1b31b80-1a3d-11eb-9c15-83bbb3940490.png)
