### PR TITLE
Use volume for mongodb data.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: pastvu/mongo:3.2.22
     volumes:
       - ./dump:/dump
+      - mongodb:/data/db
     expose:
       - '21017'
 
@@ -64,3 +65,4 @@ services:
 volumes:
   store:
   sitemap:
+  mongodb:


### PR DESCRIPTION
This will add data persistence to mongodb service, so there is no need to restore mongodb each time container has been re-created.