### PR TITLE
giveNearestPhotos geo reverse

### DIFF
--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1962,7 +1962,7 @@ async function giveNearestPhotos({ geo, type, year, year2, except, distance, lim
     }
 
     const photos = await Photo.find(query, compactFields, options).exec();
-
+    photos.forEach(photo => photo.geo.reverse());
     return { photos };
 }
 


### PR DESCRIPTION
в ответе на запрос photo.giveNearestPhotos в передаваемых координатах фотки geo изменен порядок Lat Lng по сравнению с ответом на запрос photo.giveForPage - полагаю, что это ошибка https://github.com/PastVu/pastvu/issues/197