### PR TITLE
Review maxZoom and limitZoom values for maps / Пересмотреть значения maxZoom и limitZoom для карт

### DIFF
--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -746,14 +746,7 @@ define([
 
             if (limitZoom !== undefined && maxAfter !== undefined && this.map.getZoom() > limitZoom) {
                 var layers = maxAfter.split('.');
-                if (this.layerActive().sys.id === 'osm') {
-                    this.layerActive().type.obj.on('load', function (/*evt*/) {
-                        this.selectLayer(layers[0], layers[1]);
-                    }, this);
-                } else {
-                    window.setTimeout(_.bind(this.selectLayer, this, layers[0], layers[1]), 500);
-                }
-
+                window.setTimeout(_.bind(this.selectLayer, this, layers[0], layers[1]), 300);
             }
         },
         toggleLayers: function (/*vm, event*/) {
@@ -862,9 +855,6 @@ define([
             if (layerActive.sys && layerActive.type) {
                 layerActive.sys.selected(false);
                 layerActive.type.selected(false);
-                if (layerActive.sys.id === 'osm') {
-                    layerActive.type.obj.off('load');
-                }
                 this.map.removeLayer(layerActive.type.obj);
             }
 

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -227,23 +227,21 @@ define([
                             desc: 'Спутник',
                             selected: ko.observable(false),
                             params: 'SATELLITE',
-                            maxZoom: 19
+                            maxZoom: 20
                         },
                         {
                             id: 'hyb',
                             desc: 'Гибрид',
                             selected: ko.observable(false),
                             params: 'HYBRID',
-                            maxZoom: 19
+                            maxZoom: 20
                         },
                         {
                             id: 'land',
                             desc: 'Ландшафт',
                             selected: ko.observable(false),
                             params: 'TERRAIN',
-                            maxZoom: 16,
-                            limitZoom: 15,
-                            maxAfter: 'google.scheme'
+                            maxZoom: 20
                         }
                     ])
                 });

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -12,7 +12,9 @@ define([
     var defaults = {
         sys: 'osm',
         type: 'osmosnimki',
-        minZoom: 3
+        minZoom: 3,
+        maxZoom: 18,
+        zoom: 17
     };
 
     return Cliche.extend({
@@ -416,7 +418,7 @@ define([
             var bbox;
             var fitBounds;
             var qParams = globalVM.router.params();
-            var zoom = Number(qParams.z) || (this.embedded ? 17 : (Utils.getLocalStorage('map.zoom') || Locations.current.z));
+            var zoom = Number(qParams.z) || (this.embedded ? defaults.zoom : (Utils.getLocalStorage('map.zoom') || Locations.current.z));
             var system = qParams.s || Utils.getLocalStorage(this.embedded ? 'map.embedded.sys' : 'map.sys') || defaults.sys;
             var type = qParams.t || Utils.getLocalStorage(this.embedded ? 'map.embedded.type' : 'map.type') || defaults.type;
 
@@ -468,7 +470,7 @@ define([
                 zoomControl: false // Remove default zoom control (we use our own)
             });
             if (fitBounds) {
-                this.map.fitBounds(fitBounds, { maxZoom: 18 });
+                this.map.fitBounds(fitBounds, { maxZoom: defaults.maxZoom });
             }
             this.markerManager = new MarkerManager(this.map, {
                 enabled: false,

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -307,11 +307,9 @@ define([
                             attribution: '&copy; Esri &mdash; Источники: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, и ГИС сообщество',
                             updateWhenIdle: false,
                             maxZoom: 20,
-                            maxNativeZoom: 20
+                            maxNativeZoom: 19
                         }),
-                        maxZoom: 20,
-                        limitZoom: 20,
-                        maxAfter: 'mapnik'
+                        maxZoom: 20
                     },
                     {
                         id: 'mtb',

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -333,9 +333,10 @@ define([
                             attribution: 'Аэрофотосъёмка Второй Мировой Войны <a href="http://warfly.ru/about">warfly.ru</a> (доступна для отдельных городов)',
                             updateWhenIdle: false,
                             minZoom: 9,
+                            maxZoom: 19,
                             maxNativeZoom: 17
                         }),
-                        maxZoom: 18,
+                        maxZoom: 19,
                         minZoom: 9
                     }
                 ])

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -125,6 +125,24 @@ define([
                 desc: 'OSM',
                 selected: ko.observable(false),
                 types: ko.observableArray([
+                    /* Define map types (layers).
+                     *
+                     * For fixed max zoom: specify maxZoom in TileLayer and in
+                     * type object. It will be possible to zoom map up to maxZoom
+                     * value.
+                     *
+                     * For "overzoom", set maxNativeZoom in TileLayer, and maxZoom
+                     * in both TileLayer and in type object. It will be possible to
+                     * zoom map up to maxZoom value. Layer will be "stretched" if
+                     * current zoom is above maxNativeZoom.
+                     *
+                     * For switching layer, set maxNativeZoom in TileLayer, and maxZoom
+                     * in both TileLayer and in type object. Set limitZoom in type
+                     * object. It will be possible to zoom map up to maxZoom value.
+                     * When current zoom > limitZoom, map will switch to maxAfter
+                     * layer, keeping current zoom value. maxAfter value
+                     * format is "<sys id>.<type id>", e.g. 'osm.mapnik'.
+                     */
                     {
                         id: 'osmosnimki',
                         desc: 'Kosmosnimki',
@@ -132,12 +150,12 @@ define([
                         obj: new L.TileLayer('https://osmcluster.kosmosnimki.ru/kosmo/{z}/{x}/{y}.png', {
                             attribution: '&copy; <a href="https://kosmosnimki.ru/">ООО ИТЦ "СКАНЭКС"</a> | &copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                             updateWhenIdle: false,
-                            maxZoom: 20,
+                            maxZoom: 18,
                             maxNativeZoom: 17
                         }),
-                        maxZoom: 19,
-                        limitZoom: 19,
-                        maxAfter: 'mapnik'
+                        maxZoom: 18,
+                        limitZoom: 17,
+                        maxAfter: 'osm.mapnik'
                     },
                     {
                         id: 'mapnik',
@@ -146,11 +164,9 @@ define([
                         obj: new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                             attribution: '&copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                             updateWhenIdle: false,
-                            maxZoom: 20
+                            maxZoom: 19
                         }),
-                        maxZoom: 20,
-                        limitZoom: 19,
-                        //maxAfter: 'google.scheme'
+                        maxZoom: 19
                     },
                     {
                         id: 'mapnik_de',
@@ -158,13 +174,13 @@ define([
                         selected: ko.observable(false),
                         obj: new L.TileLayer('https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png', {
                             updateWhenIdle: false,
-                            maxZoom: 20,
+                            maxZoom: 19,
                             maxNativeZoom: 18,
                             attribution: 'OSM Deutsch | &copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                         }),
-                        maxZoom: 20,
+                        maxZoom: 19,
                         limitZoom: 18,
-                        maxAfter: 'mapnik'
+                        maxAfter: 'osm.mapnik'
                     },
                     {
                         id: 'mapnik_fr',
@@ -172,12 +188,13 @@ define([
                         selected: ko.observable(false),
                         obj: new L.TileLayer('https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {
                             updateWhenIdle: false,
-                            maxZoom: 20,
+                            maxZoom: 19,
+                            maxNativeZoom: 18,
                             attribution: 'OSM Française | &copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                         }),
-                        maxZoom: 20,
-                        limitZoom: 19,
-                        maxAfter: 'mapnik'
+                        maxZoom: 19,
+                        limitZoom: 18,
+                        maxAfter: 'osm.mapnik'
                     },
                     {
                         id: 'opentopomap',
@@ -185,13 +202,13 @@ define([
                         selected: ko.observable(false),
                         obj: new L.TileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
                             updateWhenIdle: false,
-                            maxZoom: 20,
+                            maxZoom: 18,
                             maxNativeZoom: 17,
                             attribution: '&copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> | <a href="http://viewfinderpanoramas.org">SRTM</a> | Стиль карты: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
                         }),
-                        maxZoom: 20,
+                        maxZoom: 18,
                         limitZoom: 17,
-                        maxAfter: 'mapnik'
+                        maxAfter: 'osm.mapnik'
                     },
                     {
                         id: 'stamen_bw',
@@ -204,9 +221,7 @@ define([
                             ext: 'png',
                             updateWhenIdle: false
                         }),
-                        maxZoom: 20,
-                        limitZoom: 20,
-                        maxAfter: 'mapnik'
+                        maxZoom: 20
                     }
                 ])
             });
@@ -305,12 +320,12 @@ define([
                         obj: new L.TileLayer('http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png', {
                             attribution: '&copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> | <a href="http://mtbmap.cz/">mtbmap.cz</a>',
                             updateWhenIdle: false,
-                            maxZoom: 20,
-                            maxNativeZoom: 19
+                            maxZoom: 19,
+                            maxNativeZoom: 18
                         }),
-                        maxZoom: 20,
-                        limitZoom: 19,
-                        maxAfter: 'mapnik'
+                        maxZoom: 19,
+                        limitZoom: 18,
+                        maxAfter: 'osm.mapnik'
                     },
                     {
                         id: 'warfly',


### PR DESCRIPTION
This is addressing issue #218 

Google (https://github.com/PastVu/pastvu/commit/71741594b5ac827bedd8fb19e7277c610b029345):
* All maps support zoom 20. **Other question if we actually need them since they are overlayed with dev version notice #227 ?**

OSM (https://github.com/PastVu/pastvu/commit/7626e9cd4d746bfc9d23a0cb551440a8bebef23e):
* Add docs snippet to explain overzoom and switching logic.
* Fixed switching to mapnik in all applicable cases, notice that correct `maxAfter` [value format](https://github.com/PastVu/pastvu/blob/master/public/js/module/map/map.js#L734) is `<sys id>.<type id>`, e.g. `osm.mapnik`.
* Kosmosnimki - fix switching to `osm.mapnik` if map zoom is 1 step above native maximum of 17.
* Mapnik - no need to switch anywhere, supports zoom up to 19.
* Mapnik De - fix switching to `osm.mapnik` if map zoom is 1 step above native maximum of 18.
* Mapnik Fr - fix switching to `osm.mapnik` if map zoom is 1 step above native maximum of 18.
* Topograph - fix switching to `osm.mapnik` if map zoom is 1 step above native maximum of 17.
* Stamen - no need to switch anywhere, supports zoom up to 20.
* MTB - fix switching to `osm.mapnik` if map zoom is 1 step above native maximum of 18.

Ersi (https://github.com/PastVu/pastvu/commit/3dad07f8e36e95435614815fb49c784567f8bae5):
* Map natively support zoom 19, permit overzoom to 20, as it does not loose quality, Switching is not required (and never worked anyway).

Warfly (https://github.com/PastVu/pastvu/commit/e7aecfa513bb6c23f95b6286ce9e6dd3e874d82f):
* Expand overzoom to 19 (from native value of 17).