### PR TITLE
Display Nominatim place URL in region check / Показывать ссылку на Номинатим при проверке региона

### DIFF
--- a/controllers/region.js
+++ b/controllers/region.js
@@ -1565,7 +1565,7 @@ async function giveRegionsByGeo({ geo }) {
     geo.reverse();
 
     const regions = await this.call(
-        'region.getRegionsByGeoPoint', { geo, fields: { _id: 0, cid: 1, title_local: 1, parents: 1 } }
+        'region.getRegionsByGeoPoint', { geo, fields: { _id: 0, cid: 1, title_local: 1, parents: 1, title_en: 1 } }
     );
 
     if (_.isEmpty(regions)) {

--- a/public/js/module/admin/regionCheck.js
+++ b/public/js/module/admin/regionCheck.js
@@ -241,7 +241,8 @@ define([
 
             //Query Nominatim (https://nominatim.org/release-docs/develop/api/Reverse/).
             requestNominatim = $.ajax(
-                'https://nominatim.openstreetmap.org/reverse?format=geocodejson&lat=' + geo[0] + '&lon=' + geo[1],
+                'https://nominatim.openstreetmap.org/reverse?format=geocodejson&lat=' + geo[0] + '&lon=' + geo[1] +
+                '&accept-language=' + P.settings.lang,
                 {
                     crossDomain: true,
                     dataType: 'json',
@@ -276,7 +277,7 @@ define([
                             let value = {'title': geocoding.admin[reg]};
                             // For last item in the list add place_id, so URL
                             // for place details is displayed.
-                            value['place_id'] = (numRecs === count) ? geocoding.place_id : '';
+                            value.place_id = (numRecs === count) ? geocoding.place_id : '';
                             tplObj.narr.push(value);
                         }
                     }

--- a/public/js/module/admin/regionCheck.js
+++ b/public/js/module/admin/regionCheck.js
@@ -21,7 +21,7 @@ define([
         '{{##def.nurl:' +
         '<a target="_blank" href="https://nominatim.openstreetmap.org/ui/details.html?place_id={{=value.place_id}}">{{=value.title}}</a>#}}' +
         '{{##def.purl:' +
-        '<a target="_blank" href="/admin/region/{{=value.cid}}">{{=value.title_local}}</a>#}}' +
+        '<a target="_blank" href="/admin/region/{{=value.cid}}">{{=value.title}}</a>#}}' +
         '<table style="text-align: center;" border="0" cellspacing="5" cellpadding="0"><tbody>' +
         '<tr><td colspan="2">{{=it.geo}}<hr style="margin: 2px 0 5px;"></td></tr>' +
         '<tr style="font-weight: bold;"><td style="min-width:150px;">PastVu</td><td style="min-width:150px;">Nominatim</td></tr>' +
@@ -232,6 +232,10 @@ define([
                 if (err) {
                     tplObj.parr.push({'err': err.message});
                 } else {
+                    data.regions.forEach(function (region) {
+                        // Set title propertly to current language title.
+                        region.title = region.hasOwnProperty('title_' + P.settings.lang) ? region['title_' + P.settings.lang] : region.title_local;
+                    });
                     tplObj.parr = data.regions;
                 }
                 if (this.ownRegionsDeffered) {


### PR DESCRIPTION
Per request https://github.com/PastVu/pastvu/issues/131#issuecomment-723509133 this patch adds Nominatim place ID url to the last region list item.
![url](https://user-images.githubusercontent.com/329780/98468477-8994a100-21d2-11eb-8d51-071c0fe35550.png)

The url leads to the detals page where more information is available (including links to OSM types): https://nominatim.openstreetmap.org/ui/details.html?place_id=97636419

Also fixes error output for PastVu regions, so error content will be displayed.

**PS:** doT.js is amazing, simple and powerful, never came across it before.