### PR TITLE
Update log4js.json

### DIFF
--- a/log4js.json
+++ b/log4js.json
@@ -2,6 +2,9 @@
 	"replaceConsole": true,
 	"appenders": [
 		{
+			"type": "stdout"
+		},
+		{
 			"type": "file",
 			"filename": "all.log",
 			"maxLogSize": 15728640,


### PR DESCRIPTION
Add logging to stdout.

Нужно для того, чтобы инспектировать контейнеры средствами докера.
Это намного удобнее, чем инспектировать файловую систему упавших контейнеров.