### PR TITLE
Start adding public/js content to eslint / Начать добавлять клиентский код в eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,5 +8,4 @@ babel/output.js
 logs/**
 misc/**
 views/**
-public/**
 basepatch/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -664,5 +664,19 @@ module.exports = {
         'babel/no-invalid-this': 0,
         'babel/semi': 2,
         'babel/no-unused-expressions': 2, // Stop complaining about optional chaining
-    }
+    },
+    'overrides': [
+        {
+            // Old-school rules for public code.
+            'files': ['public/js/**/*.js'],
+            'rules': {
+                // no complains about using function for callback.
+                'prefer-arrow-callback': 0,
+                // arrow functions are OK, but don't mix them with ES5 syntax in the same file.
+                'object-shorthand': [2, 'consistent'],
+                // don't complain about private members of object
+                'no-underscore-dangle': 0,
+            }
+        }
+    ]
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
         eslint: {
             options: {
                 configFile: '.eslintrc.js',
-                fix: false,
+                fix: grunt.option('fix'),
             },
             all: {
                 files: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -199,7 +199,10 @@ module.exports = function (grunt) {
                         'models/**/*.js',
                         'config/!(local.config).js',
                         'config/*example',
-                        // TODO: Add public/js/ and remove it from eslintignore.
+                        // Add here public/js/ files that have been modified
+                        // in PRs, so we gradually get them all covered and
+                        // then refactor into smaller list.
+                        'public/js/lib/leaflet/extends/*.js',
                     ],
                 },
             },

--- a/public/js/lib/leaflet/extends/L.Google.js
+++ b/public/js/lib/leaflet/extends/L.Google.js
@@ -1,12 +1,12 @@
-/*global define*/
 /*
  * Google layer plugin wrapper. Loads Google Maps library with API key included.
  */
 define(['Params', 'leaflet', 'leaflet-plugins/Google'], function (P, L) {
-    let keyParam = P.settings.publicApiKeys.googleMaps.length ? '&key=' + P.settings.publicApiKeys.googleMaps : '';
-    let url = (location.protocol || 'http:') + '//maps.googleapis.com/maps/api/js?v=weekly&region=RU' + keyParam;
+    const keyParam = P.settings.publicApiKeys.googleMaps.length ? '&key=' + P.settings.publicApiKeys.googleMaps : '';
+    const url = (location.protocol || 'http:') + '//maps.googleapis.com/maps/api/js?v=weekly&region=RU' + keyParam;
+
     // Load Google Maps API library asynchronously.
-    require([ 'async!' + url]);
+    require(['async!' + url]);
 
     return L.Google;
 });

--- a/public/js/lib/leaflet/extends/L.Yandex.js
+++ b/public/js/lib/leaflet/extends/L.Yandex.js
@@ -1,52 +1,60 @@
-/*global define*/
+/* global ymaps */
 /*
  * Yandex layer plugin wrapper. Loads Yandex maps library with API key included.
  * Requires L.Yandex ^3.3.2 (https://github.com/shramov/leaflet-plugins/).
  * The loading approach used here was inspired by Yandex.addon.LoadApi.
  */
 define(['Params', 'leaflet', 'jquery', 'leaflet-plugins/Yandex'], function (P, L, $) {
-    let keyParam = P.settings.publicApiKeys.yandexMaps.length ? '&apikey=' + P.settings.publicApiKeys.yandexMaps : '';
-    let url = (location.protocol || 'http:') + '//api-maps.yandex.ru/2.1/?mode=release&lang=ru_RU' + keyParam;
+    const keyParam = P.settings.publicApiKeys.yandexMaps.length ? '&apikey=' + P.settings.publicApiKeys.yandexMaps : '';
+    const url = (location.protocol || 'http:') + '//api-maps.yandex.ru/2.1/?mode=release&lang=ru_RU' + keyParam;
 
     L.Yandex.include({
-        _initLoader: function (options) {
+        _initLoader: function () {
             if (this._loader) {
                 // Already loaded, must be yandex layer switching occured.
                 return;
             }
-            let deferred = new $.Deferred();
-            require([url], function() {
+
+            const deferred = new $.Deferred();
+
+            require([url], function () {
                 deferred.resolve();
             });
-            L.Yandex.prototype._loader = {loading: deferred};
+            L.Yandex.prototype._loader = { loading: deferred };
         },
         // Override parent't _initApi to defer map loading till ymaps is available.
         _initApi: function (afterload) {
-            let loader = this._loader;
+            const loader = this._loader;
+
             if (typeof ymaps !== 'undefined') {
                 // Library is loaded. Handle map loading to L.Yandex.
                 return ymaps.ready(this._initMapObject, this);
-            } else if (afterload || !loader) {
+            }
+
+            if (afterload || !loader) {
                 // Unlikely case when deferred object resolved, but ymaps is
                 // not available.
                 throw new Error('Yandex API is not available.');
             }
-            let loading = loader.loading;
+
+            const loading = loader.loading;
+
             // Call self with afterload param when promise is resolved.
-            loading.then(this._initApi.bind(this,'afterload'));
-        }
+            loading.then(this._initApi.bind(this, 'afterload'));
+        },
     });
     L.Yandex.addInitHook(L.Yandex.prototype._initLoader);
 
-    return function(type, options) {
+    return function (type, options) {
         // Disable point information pop-ups and "open in Yandex map" link.
         options = options || {};
         $.extend(options, {
             mapOptions: {
                 yandexMapDisablePoiInteractivity: true,
-                suppressMapOpenBlock: true
-            }
+                suppressMapOpenBlock: true,
+            },
         });
+
         return new L.Yandex(type, options);
-    }
+    };
 });

--- a/public/js/lib/leaflet/extends/L.neoMap.js
+++ b/public/js/lib/leaflet/extends/L.neoMap.js
@@ -1,9 +1,11 @@
-/*global define*/
+/*
+ * Map helper.
+ */
 define(['jquery', 'Utils', 'leaflet', 'Params'], function ($, Utils, L, P) {
     'use strict';
 
-    var deltaH;
-    var deltaV;
+    let deltaH;
+    let deltaV;
 
     function calcDelta() {
         deltaH = Math.floor(P.window.w() / 4);
@@ -28,7 +30,7 @@ define(['jquery', 'Utils', 'leaflet', 'Params'], function ($, Utils, L, P) {
         },
         right: function () {
             this.panBy(new L.Point(deltaH, 0));
-        }
+        },
 
     });
 });


### PR DESCRIPTION
Per https://github.com/PastVu/pastvu/pull/253#issue-519304369, start adding `public/js` content to linting. The idea for now is just adding content we modify as part of upcoming PRs. When we get it well covered, we may optimise directory structure to keep third-party libs separately.

Notice that requesting `public/js/**/*.js` in Gruntfile and using `.eslintignore` to add what we want to cover as `!` exceptions is not suitable option (although it was considered intially), as it produces eslint warnings for each file matching wildcard (see https://github.com/eslint/eslint/issues/5623).