### PR TITLE
MongoDB 4.x migration - Part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ run inspector client and control execution flow.
 
 0. It's recommended to create a folder where you'll be storing all the pastvu related data and code. For the sake of this readme we can call it pastvu_dev, so do `mkdir pastvu_dev`. But, of course, you can structure it however you like.
 
-1. Install [MongoDB 3.2.22 Community Edition](https://docs.mongodb.com/manual/administration/install-community). The easiest way to do it in development is by using a tarball, for instance for macos:
-https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x-tarball. In that case you can extract tarball into our pastvu_dev folder, and rename the result folder into `mongodb-3.2.22`. Having version as a postfix will come in handy when you or somebody else will be updating MongoDB version.
+1. Install [MongoDB 4.4 Community Edition](https://docs.mongodb.com/manual/administration/install-community). The easiest way to do it in development is by using a tarball, for instance for macos:
+https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x-tarball. In that case you can extract tarball into our pastvu_dev folder, and rename the result folder into `mongodb-4.4`. Having version as a postfix will come in handy when you or somebody else will be updating MongoDB version.
 
 2. Install [Redis 5.0.7](https://redis.io/topics/quickstart). It's also easier to build it from a tarball which you can extract into our pastvu_dev folder as well, and rename it to `redis-5.0.7`.
 
@@ -84,7 +84,7 @@ https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x-tarball. In tha
 
 6. Move to `pastvu` folder and install npm dependencies by doing `npm i`.
 
-By the end this section you should have `pastvu_dev` folder with these folders inside: `data`, `db`, `logs`, `mongodb-3.2.22`, `pastvu`, `redis-5.0.7`.
+By the end this section you should have `pastvu_dev` folder with these folders inside: `data`, `db`, `logs`, `mongodb-4.4`, `pastvu`, `redis-5.0.7`.
 
 ### Configuring
 
@@ -116,9 +116,9 @@ It is important that `client.hostname` is matching hostname of machine where you
 4. Download [db sample](https://varlamov.me/pastvu/github/pastvu.gz) into your `pastvu_dev` folder and import it to your MongoDB
     ```bash
    # Start MongoDB server:
-   ./mongodb-3.2.22/bin/mongod --dbpath ./db --storageEngine wiredTiger
+   ./mongodb-4.4/bin/mongod --dbpath ./db --storageEngine wiredTiger
    # Import pastvu db
-   ./mongodb-3.2.22/bin/mongorestore --gzip --db pastvu --archive="pastvu.gz"
+   ./mongodb-4.4/bin/mongorestore --gzip --db pastvu --archive="pastvu.gz"
     ```
    Now you have one default user `admin` with password `admin` and 6.5K regions in you database
 
@@ -126,7 +126,7 @@ It is important that `client.hostname` is matching hostname of machine where you
 
 There are two databases, `MongoDB` and `Redis`, and four services to start: `app` (main application), `uploader` (responsible for uploading images), `downloader` (responsible for downloading images) and `sitemap` (responsible for generating sitemap). It's not necessary to start all of them locally, only `app` is required, but if you want to work with images make sure to start corresponding services as well.
 
-1. Start MongoDB server `./mongodb-3.2.22/bin/mongod --dbpath ./db --storageEngine wiredTiger`. You can inspect it using the default terminal client `./mongodb-3.2.22/bin/mongo` or any other third-party client with gui.
+1. Start MongoDB server `./mongodb-4.4/bin/mongod --dbpath ./db --storageEngine wiredTiger`. You can inspect it using the default terminal client `./mongodb-4.4/bin/mongo` or any other third-party client with gui.
 
 2. Start Redis server `redis-server`. You can inspect it using the default terminal client `redis-cli`.
 

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -1011,7 +1011,7 @@ async function giveUserSessions({ login, withArchive = false }) {
             { _id: 0, key: 1, created: 1, stamp: 1, data: 1 },
             { lean: true, sort: { stamp: -1 } },
         ).exec(),
-        iAm.isAdmin ? SessionArchive.count({ user: user._id }).exec() : undefined,
+        iAm.isAdmin ? SessionArchive.countDocuments({ user: user._id }).exec() : undefined,
         iAm.isAdmin && withArchive ? this.call('session.giveUserArchiveSessions', { login, user }) : undefined,
     ]);
 

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -450,7 +450,7 @@ async function archiveSession(session, reason) {
     }
 
     await Promise.all([
-        session.remove(), // Remove session from collections of active sessions
+        session.deleteOne(), // Remove session from collections of active sessions
         archivingSession.save(), // Save archive session to collection of archive sessions
     ]);
 

--- a/controllers/apilog.js
+++ b/controllers/apilog.js
@@ -38,7 +38,7 @@ function saveLog() {
     clearTimeout(saveLogTimeout);
 
     if (bulk.length) {
-        ApiLog.collection.insert(bulk, { forceServerObjectId: true, checkKeys: false }, err => {
+        ApiLog.collection.insertMany(bulk, { forceServerObjectId: true, checkKeys: false }, err => {
             if (err) {
                 logger.error(err);
             }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -169,7 +169,7 @@ async function register({ login, email, pass, pass2 }) {
             text: `Перейдите по следующей ссылке: ${config.client.origin}/confirm/${confirmKey}`,
         });
     } catch (err) {
-        await User.remove({ login }).exec();
+        await User.deleteOne({ login }).exec();
 
         logger.error('Auth register after save: ', err);
         throw new AuthenticationError(constants.AUTHENTICATION_REGISTRATION);
@@ -204,7 +204,7 @@ async function recall({ login }) {
 
     const confirmKey = Utils.randomString(8);
 
-    await UserConfirm.remove({ user: user._id }).exec();
+    await UserConfirm.deleteOne({ user: user._id }).exec();
 
     await new UserConfirm({ key: confirmKey, user: user._id }).save();
 
@@ -262,7 +262,7 @@ async function passChangeRecall({ key, pass, pass2 }) {
         user.activatedate = new Date();
     }
 
-    await Promise.all([user.save(), confirm.remove()]);
+    await Promise.all([user.save(), confirm.deleteOne()]);
 
     return { message: 'Новый пароль сохранен успешно' };
 }
@@ -312,7 +312,7 @@ async function checkConfirm({ key }) {
     if (key.length === 7) { // Confirm registration
         user.active = true;
         user.activatedate = new Date();
-        await Promise.all([user.save(), confirm.remove()]);
+        await Promise.all([user.save(), confirm.deleteOne()]);
 
         return {
             message: 'Спасибо, регистрация подтверждена! Теперь вы можете войти в систему, используя ваш логин и пароль',

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -143,7 +143,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
     $update.$set.p = photo;
     $update.$set.geo = geoCluster;
 
-    const { n: count = 0 } = await ClusterModel.update({ g, z: zParam.z }, $update, { multi: false, upsert: true }).exec();
+    const { n: count = 0 } = await ClusterModel.updateOne({ g, z: zParam.z }, $update, { upsert: true }).exec();
 
     return count;
 }

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -29,8 +29,8 @@ async function recalcAll({ params, conditions }) {
 
     await ClusterParams.deleteMany({}).exec();
     await Promise.all([
-        ClusterParams.collection.insert(params, { safe: true }),
-        ClusterParams.collection.insert(conditions, { safe: true }),
+        ClusterParams.collection.insertMany(params, { safe: true }),
+        ClusterParams.collection.insertMany(conditions, { safe: true }),
     ]);
     await readClusterParams();
     await dbEval('clusterPhotosAll', [true], { nolock: true });

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -27,7 +27,7 @@ async function recalcAll({ params, conditions }) {
         throw new AuthorizationError();
     }
 
-    await ClusterParams.remove({}).exec();
+    await ClusterParams.deleteMany({}).exec();
     await Promise.all([
         ClusterParams.collection.insert(params, { safe: true }),
         ClusterParams.collection.insert(conditions, { safe: true }),
@@ -79,7 +79,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
 
     if (cluster && c <= 1 && inc === -1) {
         // If after deletion photo from cluster, cluster become empty - remove it
-        return ClusterModel.remove({ g, z: zParam.z }).exec();
+        return ClusterModel.deleteMany({ g, z: zParam.z }).exec();
     }
 
     if (inc !== 0) {

--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -1056,17 +1056,16 @@ async function remove(data) {
         delInfo.reason.desc = Utils.inputIncomingParse(data.reason.desc).result;
     }
 
-    await commentModel.update({ cid }, { $set: { lastChanged: delInfo.stamp, del: delInfo } }).exec();
+    await commentModel.updateOne({ cid }, { $set: { lastChanged: delInfo.stamp, del: delInfo } }).exec();
 
     const countCommentsRemoved = (childsCids.length || 0) + 1;
 
     if (childsCids.length) {
         const delInfoChilds = Object.assign(_.omit(delInfo, 'reason'), { origin: cid });
 
-        await commentModel.update(
+        await commentModel.updateMany(
             { cid: { $in: childsCids } },
-            { $set: { lastChanged: delInfo.stamp, del: delInfoChilds } },
-            { multi: true }
+            { $set: { lastChanged: delInfo.stamp, del: delInfoChilds } }
         ).exec();
     }
 
@@ -1097,7 +1096,7 @@ async function remove(data) {
             userObj.user.ccount = userObj.user.ccount - count;
             promises.push(session.saveEmitUser({ usObj: userObj }));
         } else {
-            promises.push(User.update({ _id: userId }, { $inc: { ccount: -count } }).exec());
+            promises.push(User.updateOne({ _id: userId }, { $inc: { ccount: -count } }).exec());
         }
     }
 
@@ -1220,7 +1219,7 @@ async function restore({ cid, type }) {
         hist[1].roleregion = canModerate;
     }
 
-    await commentModel.update(
+    await commentModel.updateOne(
         { cid }, { $set: { lastChanged: stamp }, $unset: { del: 1 }, $push: { hist: { $each: hist } } }
     ).exec();
 
@@ -1234,11 +1233,11 @@ async function restore({ cid, type }) {
             histChilds[1].roleregion = canModerate;
         }
 
-        await commentModel.update({ obj: obj._id, 'del.origin': cid }, {
+        await commentModel.updateMany({ obj: obj._id, 'del.origin': cid }, {
             $set: { lastChanged: stamp },
             $unset: { del: 1 },
             $push: { hist: { $each: histChilds } },
-        }, { multi: true }).exec();
+        }).exec();
     }
 
     let frags = obj.frags && obj.frags.toObject();
@@ -1270,7 +1269,7 @@ async function restore({ cid, type }) {
             userObj.user.ccount = userObj.user.ccount + ccount;
             promises.push(session.saveEmitUser({ usObj: userObj }));
         } else {
-            promises.push(User.update({ _id: userId }, { $inc: { ccount } }).exec());
+            promises.push(User.updateOne({ _id: userId }, { $inc: { ccount } }).exec());
         }
     }
 
@@ -1587,7 +1586,7 @@ async function setNoComments({ cid, type = 'photo', val: nocomments }) {
 }
 
 export async function changeObjCommentsStatus({ obj: { _id: objId, s } }) {
-    const { n: count = 0 } = await Comment.update({ obj: objId }, { $set: { s } }, { multi: true }).exec();
+    const { n: count = 0 } = await Comment.updateMany({ obj: objId }, { $set: { s } }).exec();
 
     return count;
 }
@@ -1623,7 +1622,7 @@ export async function changeObjCommentsVisibility({ obj, hide }) {
             userObj.user.ccount = userObj.user.ccount + cdelta;
             session.saveEmitUser({ usObj: userObj });
         } else {
-            User.update({ _id: userId }, { $inc: { ccount: cdelta } }).exec();
+            User.updateOne({ _id: userId }, { $inc: { ccount: cdelta } }).exec();
         }
     }
 
@@ -1637,7 +1636,7 @@ export async function changeObjCommentsVisibility({ obj, hide }) {
 export async function changePhotoCommentsType({ photo: { _id: objId, type } }) {
     const command = { $set: { type } };
 
-    const { n: count = 0 } = await Comment.update({ obj: objId }, command, { multi: true }).exec();
+    const { n: count = 0 } = await Comment.updateMany({ obj: objId }, command).exec();
 
     return { count };
 }

--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -288,7 +288,7 @@ async function commentsTreeBuildCanModerate({ iAm, type, commentModel, obj, show
         // with notification reset if it scheduled
         userObjectRelController.setCommentView(obj._id, iAm.user._id, type),
         // News doesn't contain number of deleted comments, count it dynamically
-        type === 'news' ? await commentModel.count({ obj: obj._id, del: { $exists: true } }).exec() : undefined,
+        type === 'news' ? await commentModel.countDocuments({ obj: obj._id, del: { $exists: true } }).exec() : undefined,
     ]);
 
     const commentsTree = [];
@@ -637,10 +637,10 @@ async function giveForUser({ login, page = 1, type = 'photo', active = true, del
     let countPhoto;
 
     const [countActiveP, countActiveN, countDelP = 0, countDelN = 0] = await Promise.all([
-        Comment.count({ user: userId, del: null }).exec(),
-        CommentN.count({ user: userId, del: null }).exec(),
-        canSeeDel ? Comment.count({ user: userId, del: { $exists: true } }).exec() : undefined,
-        canSeeDel ? CommentN.count({ user: userId, del: { $exists: true } }).exec() : undefined,
+        Comment.countDocuments({ user: userId, del: null }).exec(),
+        CommentN.countDocuments({ user: userId, del: null }).exec(),
+        canSeeDel ? Comment.countDocuments({ user: userId, del: { $exists: true } }).exec() : undefined,
+        canSeeDel ? CommentN.countDocuments({ user: userId, del: { $exists: true } }).exec() : undefined,
     ]);
 
     const countActive = countActiveP + countActiveN;
@@ -989,7 +989,7 @@ async function remove(data) {
     }
 
     // Count amout of unremoved children
-    const childCount = await commentModel.count({ obj: obj._id, parent: cid, del: null }).exec();
+    const childCount = await commentModel.countDocuments({ obj: obj._id, parent: cid, del: null }).exec();
 
     // Regular user can remove if there no unremoved comments and it's his own fresh comment
     const canEdit = !childCount && permissions.canEdit(comment, data.type, obj, iAm);

--- a/controllers/connection.js
+++ b/controllers/connection.js
@@ -41,25 +41,21 @@ function init({ mongo, redis, logger = log4js.getLogger('app') }) {
         mongoose.Promise = Promise;
 
         connectionPromises.push(new Promise((resolve, reject) => {
-            db = mongoose.createConnection() // http://mongoosejs.com/docs/api.html#connection_Connection
+            db = mongoose.createConnection() // https://mongoosejs.com/docs/api/mongoose.html#mongoose_Mongoose-createConnection
                 .once('open', openHandler)
                 .once('error', errFirstHandler);
 
-            db.open(uri, {
-                db: { native_parser: true, promiseLibrary: Promise },
-                server: {
-                    poolSize,
-                    auto_reconnect: true,
-                    reconnectTries: 10000,
-                    reconnectInterval: 1000,
-                    socketOptions: {
-                        noDelay: true,
-                        keepAlive: 0, // Enable keep alive connection
-                        autoReconnect: true,
-                        socketTimeoutMS: 0,
-                        connectTimeoutMS: ms('5m'),
-                    },
-                },
+            db.openUri(uri, {
+                poolSize,
+                promiseLibrary: Promise,
+                noDelay: true,
+                keepAlive: 0, // Enable keep alive connection
+                socketTimeoutMS: 0,
+                connectTimeoutMS: ms('5m'),
+                useUnifiedTopology: true, // Use new topology engine (since MongoDB driver 3.3)
+                useNewUrlParser: true, // Use new connection string parser.
+                useCreateIndex: true, // Use createIndex internally (ensureIndex is deprecated in MongoDB driver 3.2).
+                useFindAndModify: false, // Use findOneAndUpdate interally (findAndModify is deprecated in MongoDB driver 3.1).
             });
 
             async function openHandler() {

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -244,7 +244,7 @@ async function conveyerClear({ value }) {
     if (value === true) {
         conveyerEnabled = value;
 
-        ({ result: { n: removedCount = 0 } } = await PhotoConveyer.remove({ converting: { $exists: false } }).exec());
+        ({ n: removedCount = 0 } = await PhotoConveyer.deleteMany({ converting: { $exists: false } }).exec());
     }
 
     conveyerLength = await PhotoConveyer.estimatedDocumentCount().exec();
@@ -306,7 +306,7 @@ async function conveyerControl() {
         photo.conv = undefined; // Set undefined to remove properties
         photo.convqueue = undefined;
         photo.converted = new Date(); // Save last converted stamp
-        await Promise.all([photo.save(), photoConv.remove()]);
+        await Promise.all([photo.save(), photoConv.deleteOne()]);
 
         working -= 1;
 
@@ -687,7 +687,7 @@ export async function removePhotos(cids) {
         return 0;
     }
 
-    const { result: { n: removedCount = 0 } } = await PhotoConveyer.remove({ cid: { $in: cids } }).exec();
+    const { n: removedCount = 0 } = await PhotoConveyer.deleteMany({ cid: { $in: cids } }).exec();
 
     conveyerLength -= removedCount;
 

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -646,7 +646,7 @@ export async function addPhotos(data, priority, potectPublicOnly) {
     }
 
     if (toConvertObjs.length) {
-        await PhotoConveyer.collection.insert(toConvertObjs, { safe: true });
+        await PhotoConveyer.collection.insertMany(toConvertObjs, { safe: true });
 
         conveyerLength += toConvertObjs.length;
         conveyerMaxLength = Math.max(conveyerLength, conveyerMaxLength);

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -247,7 +247,7 @@ async function conveyerClear({ value }) {
         ({ result: { n: removedCount = 0 } } = await PhotoConveyer.remove({ converting: { $exists: false } }).exec());
     }
 
-    conveyerLength = await PhotoConveyer.count({}).exec();
+    conveyerLength = await PhotoConveyer.estimatedDocumentCount().exec();
 
     return { message: `Cleared ok! Removed ${removedCount}, left ${conveyerLength}` };
 }
@@ -710,7 +710,7 @@ export async function removePhotos(cids) {
         conveyerControl();
     }, 4000);
 
-    const count = await PhotoConveyer.count({}).exec();
+    const count = await PhotoConveyer.estimatedDocumentCount().exec();
 
     conveyerLength = Math.max(count, conveyerMaxLength);
     conveyerMaxLength = conveyerLength;

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -609,7 +609,7 @@ export async function movePhotoFiles({ photo, copy = false, toProtected = false 
 
         const { signature, fileParam } = await getFileSign(photo, path.join(targetDir, 'd', filePath));
 
-        await Photo.update(
+        await Photo.updateOne(
             { cid: photo.cid }, { $set: { file: filePath + fileParam, signs: signature || '', converted: new Date() } }
         ).exec();
     }
@@ -700,8 +700,8 @@ export async function removePhotos(cids) {
     // Запускаем конвейер после рестарта сервера, устанавливаем все недоконвертированные фото обратно в false
     setTimeout(async () => {
         try {
-            await PhotoConveyer.update(
-                { converting: { $exists: true } }, { $unset: { converting: 1 } }, { multi: true }
+            await PhotoConveyer.updateMany(
+                { converting: { $exists: true } }, { $unset: { converting: 1 } }
             ).exec();
         } catch (err) {
             return logger.error(err);

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -172,22 +172,22 @@ const giveStats = (function () {
         ] = await Promise.all([
             Photo.aggregate(aggregateParams).exec(),
 
-            Photo.count({}).exec(),
-            Photo.count({ s: 5 }).exec(),
-            User.count({ active: true }).exec(),
+            Photo.estimatedDocumentCount().exec(),
+            Photo.countDocuments({ s: 5 }).exec(),
+            User.countDocuments({ active: true }).exec(),
 
-            Photo.count({ s: 5, adate: { $gt: dayStart } }).exec(),
-            Photo.count({ s: 5, adate: { $gt: weekStart } }).exec(),
+            Photo.countDocuments({ s: 5, adate: { $gt: dayStart } }).exec(),
+            Photo.countDocuments({ s: 5, adate: { $gt: weekStart } }).exec(),
 
-            Comment.count({}).exec(),
-            CommentN.count({}).exec(),
+            Comment.estimatedDocumentCount().exec(),
+            CommentN.estimatedDocumentCount().exec(),
 
-            Comment.count({ s: 5, del: null }).exec(),
-            CommentN.count({ del: null }).exec(),
-            Comment.count({ s: 5, stamp: { $gt: dayStart }, del: null }).exec(),
-            CommentN.count({ stamp: { $gt: dayStart }, del: null }).exec(),
-            Comment.count({ s: 5, stamp: { $gt: weekStart }, del: null }).exec(),
-            CommentN.count({ stamp: { $gt: weekStart }, del: null }).exec(),
+            Comment.countDocuments({ s: 5, del: null }).exec(),
+            CommentN.countDocuments({ del: null }).exec(),
+            Comment.countDocuments({ s: 5, stamp: { $gt: dayStart }, del: null }).exec(),
+            CommentN.countDocuments({ stamp: { $gt: dayStart }, del: null }).exec(),
+            Comment.countDocuments({ s: 5, stamp: { $gt: weekStart }, del: null }).exec(),
+            CommentN.countDocuments({ stamp: { $gt: weekStart }, del: null }).exec(),
         ]);
 
         return {

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -673,7 +673,7 @@ function photoFromMap({ photo, paintingMap }) {
 
     return Promise.all([
         this.call('cluster.declusterPhoto', { photo, isPainting: paintingMap }),
-        MapModel.remove({ cid: photo.cid }).exec(),
+        MapModel.deleteMany({ cid: photo.cid }).exec(),
     ]);
 }
 

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1480,12 +1480,12 @@ async function givePhotos({ filter, options: { skip = 0, limit = 40, random = fa
 
             [photos, count] = await Promise.all([
                 Photo.find(query, fieldsSelect, { lean: true, limit }).exec(),
-                Photo.count(countQuery).exec(),
+                Photo.countDocuments(countQuery).exec(),
             ]);
         } else {
             [photos, count] = await Promise.all([
                 Photo.find(query, fieldsSelect, { lean: true, skip, limit, sort: { sdate: -1 } }).exec(),
-                Photo.count(query).exec(),
+                Photo.countDocuments(query).exec(),
             ]);
         }
 
@@ -3414,7 +3414,7 @@ async function resetPhotosAnticache() {
 async function syncUnpublishedPhotosWithRedis() {
     try {
         let [actualCount = 0, redisCount] = await Promise.all([
-            Photo.count({ s: { $ne: status.PUBLIC } }).exec(),
+            Photo.countDocuments({ s: { $ne: status.PUBLIC } }).exec(),
             dbRedis.getAsync('notpublic:count'),
         ]);
 

--- a/controllers/region.js
+++ b/controllers/region.js
@@ -536,7 +536,7 @@ async function getChildsLenByLevel(region) {
 
         while (level++ < maxRegionLevel) { // level инкрементируется после сравнения
             childrenQuery.parents = { $size: level };
-            promises.push(Region.count(childrenQuery).exec());
+            promises.push(Region.countDocuments(childrenQuery).exec());
         }
 
         return _.compact(await Promise.all(promises));
@@ -677,7 +677,7 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
     // Calculate number of photos belongs to the region
     const countQuery = { ['r' + levelWas]: region.cid };
     const [affectedPhotos, affectedComments] = await Promise.all([
-        Photo.count(countQuery).exec(), Comment.count(countQuery).exec(),
+        Photo.countDocuments(countQuery).exec(), Comment.countDocuments(countQuery).exec(),
     ]);
 
     let affectedUsers;
@@ -1446,7 +1446,7 @@ export async function getRegionsCountByLevel() {
     const promises = [];
 
     for (let i = 0; i <= maxRegionLevel; i++) {
-        promises.push(Region.count({ parents: { $size: i } }).exec());
+        promises.push(Region.countDocuments({ parents: { $size: i } }).exec());
     }
 
     return Promise.all(promises);

--- a/controllers/region.js
+++ b/controllers/region.js
@@ -1311,9 +1311,9 @@ async function remove(data) {
         // Update comments of included photos
         Comment.update(objectsMatchQuery, objectsUpdateQuery, { multi: true }).exec(),
         // Remove child regions
-        Region.remove({ parents: regionToRemove.cid }).exec(),
+        Region.deleteMany({ parents: regionToRemove.cid }).exec(),
         // Remove this regions
-        regionToRemove.remove(),
+        regionToRemove.deleteOne(),
     ]);
 
     // If removing region has parent, recalc parents stat
@@ -2217,7 +2217,7 @@ async function removeDrainedRegionStat() {
         const photoCidsToRemove = Array.from(drainingPhotoCidsSet);
 
         drainingPhotoCidsSet = new Set();
-        await RegionStatQueue.remove({ cid: { $in: photoCidsToRemove } }).exec();
+        await RegionStatQueue.deleteMany({ cid: { $in: photoCidsToRemove } }).exec();
     }
 }
 

--- a/controllers/region.js
+++ b/controllers/region.js
@@ -467,15 +467,15 @@ async function calcRegionIncludes(cidOrRegion) {
     // First clear assignment of objects with coordinates to region
     const unsetObject = { $unset: { [level]: 1 } };
     const [{ n: photosCountBefore = 0 }, { n: commentsCountBefore = 0 }] = await Promise.all([
-        Photo.update({ geo: { $exists: true }, [level]: region.cid }, unsetObject, { multi: true }).exec(),
-        Comment.update({ geo: { $exists: true }, [level]: region.cid }, unsetObject, { multi: true }).exec(),
+        Photo.updateMany({ geo: { $exists: true }, [level]: region.cid }, unsetObject).exec(),
+        Comment.updateMany({ geo: { $exists: true }, [level]: region.cid }, unsetObject).exec(),
     ]);
 
     // Then assign to region on located in it polygon objects
     const setObject = { $set: { [level]: region.cid } };
     const [{ n: photosCountAfter = 0 }, { n: commentsCountAfter = 0 }] = await Promise.all([
-        Photo.update({ geo: { $geoWithin: { $geometry: region.geo } } }, setObject, { multi: true }).exec(),
-        Comment.update({ geo: { $geoWithin: { $geometry: region.geo } } }, setObject, { multi: true }).exec(),
+        Photo.updateMany({ geo: { $geoWithin: { $geometry: region.geo } } }, setObject).exec(),
+        Comment.updateMany({ geo: { $geoWithin: { $geometry: region.geo } } }, setObject).exec(),
     ]);
 
     return { cid: region.cid, photosCountBefore, commentsCountBefore, photosCountAfter, commentsCountAfter };
@@ -568,8 +568,8 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
 
     function updateObjects(query, update) {
         return Promise.all([
-            Photo.update(query, update, { multi: true }).exec(),
-            Comment.update(query, update, { multi: true }).exec(),
+            Photo.updateMany(query, update).exec(),
+            Comment.updateMany(query, update).exec(),
         ]);
     }
 
@@ -655,20 +655,20 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
         const [{ n: affectedUsers = 0 }, { n: affectedMods = 0 }] = await Promise.all([
             // Remove subscription on moving regions of those users, who have subscription on new and on parent regions,
             // because in this case they'll have subscription on children automatically
-            User.update({
+            User.updateMany({
                 $and: [
                     { regions: { $in: parentRegionsIds } },
                     { regions: { $in: movingRegionsIds } },
                 ],
-            }, { $pull: { regions: { $in: movingRegionsIds } } }, { multi: true }).exec(),
+            }, { $pull: { regions: { $in: movingRegionsIds } } }).exec(),
 
             // Tha same with moderated regions
-            User.update({
+            User.updateMany({
                 $and: [
                     { mod_regions: { $in: parentRegionsIds } },
                     { mod_regions: { $in: movingRegionsIds } },
                 ],
-            }, { $pull: { mod_regions: { $in: movingRegionsIds } } }, { multi: true }).exec(),
+            }, { $pull: { mod_regions: { $in: movingRegionsIds } } }).exec(),
         ]);
 
         return { affectedUsers, affectedMods };
@@ -689,8 +689,8 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
         regionsDiff = _.difference(oldParentsArray, region.parents);
 
         // Remove differens in regions from children of moving region, eg move them up too
-        await Region.update(
-            { parents: region.cid }, { $pull: { parents: { $in: regionsDiff } } }, { multi: true }
+        await Region.updateMany(
+            { parents: region.cid }, { $pull: { parents: { $in: regionsDiff } } }
         ).exec();
 
         if (affectedPhotos) {
@@ -702,10 +702,9 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
         regionsDiff = _.difference(region.parents, oldParentsArray);
 
         // Insert added parent regions to children of moving region, eg move them down also
-        await Region.update(
+        await Region.updateMany(
             { parents: region.cid },
-            { $push: { parents: { $each: regionsDiff, $position: levelWas } } },
-            { multi: true }
+            { $push: { parents: { $each: regionsDiff, $position: levelWas } } }
         ).exec();
 
         if (!affectedPhotos) {
@@ -722,16 +721,15 @@ async function changeRegionParentExternality(region, oldParentsArray, childLenAr
         // Move region to ANOTHER BRANCH
 
         // Remove all parents of this region from its children
-        await Region.update(
-            { parents: region.cid }, { $pull: { parents: { $in: oldParentsArray } } }, { multi: true }
+        await Region.updateMany(
+            { parents: region.cid }, { $pull: { parents: { $in: oldParentsArray } } }
         ).exec();
 
         // Insert added parent regions to children of moving region, eg move them down also
         // Insert all parents of region to its children
-        await Region.update(
+        await Region.updateMany(
             { parents: region.cid },
-            { $push: { parents: { $each: region.parents, $position: 0 } } },
-            { multi: true }
+            { $push: { parents: { $each: region.parents, $position: 0 } } }
         ).exec();
 
         if (affectedPhotos && levelNew !== levelWas) {
@@ -1277,13 +1275,13 @@ async function remove(data) {
     removingRegionsIds.push(regionToRemove._id);
 
     // Replace home regions
-    const { n: homeAffectedUsers = 0 } = await User.update(
-        { regionHome: { $in: removingRegionsIds } }, { $set: { regionHome: parentRegion._id } }, { multi: true }
+    const { n: homeAffectedUsers = 0 } = await User.updateMany(
+        { regionHome: { $in: removingRegionsIds } }, { $set: { regionHome: parentRegion._id } }
     ).exec();
 
     // Unsubscribe all users from removing regions ('my regions')
-    const { n: affectedUsers = 0 } = await User.update(
-        { regions: { $in: removingRegionsIds } }, { $pull: { regions: { $in: removingRegionsIds } } }, { multi: true }
+    const { n: affectedUsers = 0 } = await User.updateMany(
+        { regions: { $in: removingRegionsIds } }, { $pull: { regions: { $in: removingRegionsIds } } }
     ).exec();
 
     // Remove removing regions from moderated by users
@@ -1307,9 +1305,9 @@ async function remove(data) {
 
     const [{ n: affectedPhotos = 0 }, { n: affectedComments = 0 }] = await Promise.all([
         // Update included photos
-        Photo.update(objectsMatchQuery, objectsUpdateQuery, { multi: true }).exec(),
+        Photo.updateMany(objectsMatchQuery, objectsUpdateQuery).exec(),
         // Update comments of included photos
-        Comment.update(objectsMatchQuery, objectsUpdateQuery, { multi: true }).exec(),
+        Comment.updateMany(objectsMatchQuery, objectsUpdateQuery).exec(),
         // Remove child regions
         Region.deleteMany({ parents: regionToRemove.cid }).exec(),
         // Remove this regions
@@ -1355,17 +1353,15 @@ async function removeRegionsFromMods(usersQuery, regionsIds) {
 
     if (modUsersCids.length) {
         // Remove regions from finded moderators
-        const { n: affectedMods = 0 } = await User.update(
+        const { n: affectedMods = 0 } = await User.updateMany(
             { cid: { $in: modUsersCids } },
-            { $pull: { mod_regions: { $in: regionsIds } } },
-            { multi: true }
+            { $pull: { mod_regions: { $in: regionsIds } } }
         ).exec();
 
         // Revoke moderation role from users, in whose no moderation regions left after regions removal
-        const { n: affectedModsLose = 0 } = await User.update(
+        const { n: affectedModsLose = 0 } = await User.updateMany(
             { cid: { $in: modUsersCids }, mod_regions: { $size: 0 } },
-            { $unset: { role: 1, mod_regions: 1 } },
-            { multi: true }
+            { $unset: { role: 1, mod_regions: 1 } }
         ).exec();
 
         return { affectedMods, affectedModsLose };
@@ -1695,7 +1691,7 @@ async function updateObjsRegions({ model, criteria = {}, regions = [], additiona
     }
 
     if (Object.keys($update).length) {
-        await model.update(criteria, $update, { multi: true }).exec();
+        await model.updateMany(criteria, $update).exec();
     }
 }
 
@@ -1747,7 +1743,7 @@ export async function setUserRegions({ login, regions: regionsCids, field }) {
         $update.$set = { [field]: [...regionsIdsSet] };
     }
 
-    return User.update({ login }, $update).exec();
+    return User.updateOne({ login }, $update).exec();
 }
 
 async function saveUserHomeRegion({ login, cid }) {
@@ -2178,7 +2174,7 @@ function regionStatQueueDrain(limit) {
             }, Object.create(null));
 
             if (count) {
-                updatePromises.push(Region.update({ cid }, { $inc }).exec());
+                updatePromises.push(Region.updateOne({ cid }, { $inc }).exec());
 
                 const region = regionCacheHash[cid];
 
@@ -2260,7 +2256,7 @@ export async function putPhotoToRegionStatQueue(oldPhoto, newPhoto) {
         updateMethod = '$setOnInsert';
     }
 
-    await RegionStatQueue.update({ cid }, { [updateMethod]: {
+    await RegionStatQueue.updateOne({ cid }, { [updateMethod]: {
         stamp: new Date(), cid,
         state: { s, type, geo: _.isEmpty(geo) ? undefined : geo, regions: regionCids, cc, ccd },
     } }, { upsert: true }).exec();

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -168,7 +168,7 @@ export async function commentViewed(objId, user, setInRel) {
     }
 
     // Calculate amount of notification which ready for sending to user
-    const count = await UserObjectRel.count({ user: user._id, sbscr_noty: true }).exec();
+    const count = await UserObjectRel.countDocuments({ user: user._id, sbscr_noty: true }).exec();
 
     if (count === 0) {
         // If there is no notifications ready fo sending left, reset scheduled sending to user
@@ -500,10 +500,10 @@ async function giveUserSubscriptions({ login, page = 1, type = 'photo' }) {
 
     const [countPhoto = 0, countNews = 0, { nextnoty: nextNoty } = {}] = await Promise.all([
         // Count total number of photos in subscriptions
-        UserObjectRel.count({ user: userId, type: 'photo', sbscr_create: { $exists: true } }).exec(),
+        UserObjectRel.countDocuments({ user: userId, type: 'photo', sbscr_create: { $exists: true } }).exec(),
 
         // Count total number of news in subscriptions
-        UserObjectRel.count({ user: userId, type: 'news', sbscr_create: { $exists: true } }).exec(),
+        UserObjectRel.countDocuments({ user: userId, type: 'news', sbscr_create: { $exists: true } }).exec(),
 
         // Take time of next scheduled notification
         await UserNoty.findOne(

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -59,13 +59,13 @@ async function subscribeUser({ cid, type = 'photo', subscribe }) {
 
     if (subscribe) {
         // TODO: Подумать, что делать с новыми комментариями появившимися после просмотра объекта, но до подписки
-        await UserObjectRel.update(
+        await UserObjectRel.updateOne(
             { obj: obj._id, user: iAm.user._id, type },
             { $set: { sbscr_create: new Date() } },
             { upsert: true }
         ).exec();
     } else {
-        await UserObjectRel.update(
+        await UserObjectRel.updateOne(
             { obj: obj._id, user: iAm.user._id, type },
             { $unset: { sbscr_create: 1, sbscr_noty_change: 1, sbscr_noty: 1 } }
         ).exec();
@@ -90,7 +90,7 @@ export async function subscribeUserByIds({ user, objId, setCommentView, type = '
         $update.$set.comments = stamp;
     }
 
-    return UserObjectRel.update({ obj: objId, user: userId, type }, $update, { upsert: true }).exec();
+    return UserObjectRel.updateOne({ obj: objId, user: userId, type }, $update, { upsert: true }).exec();
 }
 
 /**
@@ -105,7 +105,7 @@ async function unSubscribeObj({ objId, userId }) {
         query.user = userId;
     }
 
-    return UserObjectRel.update(
+    return UserObjectRel.updateOne(
         query, { $unset: { sbscr_create: 1, sbscr_noty_change: 1, sbscr_noty: 1 } }
     ).exec();
 }
@@ -137,10 +137,9 @@ export async function commentAdded(objId, user, stamp = new Date()) {
     }
 
     // Set flag of readiness of notification by object for subscribed users
-    await UserObjectRel.update(
+    await UserObjectRel.updateMany(
         { _id: { $in: ids } },
-        { $set: { sbscr_noty_change: stamp, sbscr_noty: true } },
-        { multi: true }
+        { $set: { sbscr_noty_change: stamp, sbscr_noty: true } }
     ).exec();
 
     scheduleUserNotice(users); // Call scheduler of notification sending for subscribed users
@@ -156,7 +155,7 @@ export async function commentAdded(objId, user, stamp = new Date()) {
  */
 export async function commentViewed(objId, user, setInRel) {
     if (setInRel) {
-        const { n: numberAffected = 0 } = await UserObjectRel.update(
+        const { n: numberAffected = 0 } = await UserObjectRel.updateOne(
             { obj: objId, user: user._id },
             { $unset: { sbscr_noty: 1 }, $set: { sbscr_noty_change: new Date() } },
             { upsert: false }
@@ -172,7 +171,7 @@ export async function commentViewed(objId, user, setInRel) {
 
     if (count === 0) {
         // If there is no notifications ready fo sending left, reset scheduled sending to user
-        await UserNoty.update({ user: user._id }, { $unset: { nextnoty: 1 } }).exec();
+        await UserNoty.updateOne({ user: user._id }, { $unset: { nextnoty: 1 } }).exec();
     }
 }
 
@@ -199,7 +198,7 @@ export async function userThrottleChange(userId, newThrottle) {
         Math.max(userNoty.lastnoty.getTime() + newThrottle, nearestNoticeTimeStamp) :
         nearestNoticeTimeStamp;
 
-    await UserNoty.update({ user: userId }, { $set: { nextnoty: new Date(newNextNoty) } }).exec();
+    await UserNoty.updateOne({ user: userId }, { $set: { nextnoty: new Date(newNextNoty) } }).exec();
 }
 
 /**
@@ -251,7 +250,7 @@ async function scheduleUserNotice(users) {
 
     for (const userId of users) {
         if (usersNotyHash[userId] !== false) {
-            UserNoty.update(
+            UserNoty.updateOne(
                 { user: userId },
                 { $set: { nextnoty: new Date(usersNotyHash[userId] || nearestNoticeTimeStamp) } },
                 { upsert: true }
@@ -302,10 +301,9 @@ const notifierConveyor = (function () {
                 return sendUserNotice(user).catch(err => logger.error('sendUserNotice', err));
             }));
 
-            await UserNoty.update(
+            await UserNoty.updateMany(
                 { user: { $in: userIds } },
-                { $set: { lastnoty: nowDate }, $unset: { nextnoty: 1 } },
-                { multi: true }
+                { $set: { lastnoty: nowDate }, $unset: { nextnoty: 1 } }
             ).exec();
         } catch (err) {
             logger.error('conveyorStep', err);
@@ -351,10 +349,9 @@ async function sendUserNotice(userId) {
     // Reset flag of rediness to notification (sbscr_noty) of sent objects
     async function resetRelsNoty() {
         if (!_.isEmpty(relIds)) {
-            return UserObjectRel.update(
+            return UserObjectRel.updateMany(
                 { _id: { $in: relIds } },
-                { $unset: { sbscr_noty: 1 }, $set: { sbscr_noty_change: new Date() } },
-                { multi: true }
+                { $unset: { sbscr_noty: 1 }, $set: { sbscr_noty_change: new Date() } }
             ).exec();
         }
     }

--- a/controllers/systemjs.js
+++ b/controllers/systemjs.js
@@ -72,13 +72,13 @@ waitDb.then(db => {
             db.sessions.deleteOne({ key: session.key });
 
             if (counter >= castBulkBy) {
-                db.sessions_archive.insert(insertBulk, { ordered: false });
+                db.sessions_archive.insertMany(insertBulk, { ordered: false });
                 insertBulk = [];
             }
         });
 
         if (insertBulk.length) {
-            db.sessions_archive.insert(insertBulk, { ordered: false });
+            db.sessions_archive.insertMany(insertBulk, { ordered: false });
         }
 
         return {
@@ -227,7 +227,7 @@ waitDb.then(db => {
                     }
                 }
 
-                db.clusters.insert(clustersArrInner);
+                db.clusters.insertMany(clustersArrInner);
                 clustersInserted += clustersArrInner.length;
                 print(
                     clusterZoom.z + ': Inserted ' + clustersInserted + '/' + clustersCount + ' clusters ok. ' +
@@ -266,7 +266,7 @@ waitDb.then(db => {
             })
             .sort({ cid: 1 })
             .forEach(photo => {
-                db.photos_map.insert({
+                db.photos_map.insertOne({
                     cid: photo.cid,
                     geo: photo.geo,
                     file: photo.file,
@@ -293,7 +293,7 @@ waitDb.then(db => {
             })
             .sort({ cid: 1 })
             .forEach(photo => {
-                db.paintings_map.insert({
+                db.paintings_map.insertOne({
                     cid: photo.cid,
                     geo: photo.geo,
                     file: photo.file,
@@ -370,7 +370,7 @@ waitDb.then(db => {
         });
 
         if (conveyer.length) {
-            db.photos_conveyer.insert(conveyer);
+            db.photos_conveyer.insertMany(conveyer);
         }
 
         return {

--- a/controllers/systemjs.js
+++ b/controllers/systemjs.js
@@ -49,7 +49,7 @@ waitDb.then(db => {
         const anonQuery = { anonym: { $exists: true }, stamp: { $lte: new Date(start - SESSION_ANON_LIFE) } };
 
         // Simply remove anonymous sessions older then SESSION_ANON_LIFE, there is no point in storing them
-        const countRemoved = db.sessions.remove(anonQuery).nRemoved;
+        const countRemoved = db.sessions.deleteMany(anonQuery).nRemoved;
 
         // Move each expired registered user session to sessions_archive
         db.sessions.find(userQuery).limit(5000).forEach(session => {
@@ -69,7 +69,7 @@ waitDb.then(db => {
             insertBulk.push(session);
             resultKeys.push(session.key);
 
-            db.sessions.remove({ key: session.key });
+            db.sessions.deleteOne({ key: session.key });
 
             if (counter >= castBulkBy) {
                 db.sessions_archive.insert(insertBulk, { ordered: false });
@@ -187,7 +187,7 @@ waitDb.then(db => {
             });
 
             print(clusterZoom.z + ': ' + clustersCount + ' clusters ready for inserting ' + (Date.now() - startTime) / 1000 + 's');
-            db.clusters.remove({ z: clusterZoom.z });
+            db.clusters.deleteMany({ z: clusterZoom.z });
 
             clustersCounter = clustersArr.length;
 
@@ -250,7 +250,7 @@ waitDb.then(db => {
         var startTime = Date.now();
 
         print('Clearing photos map collection');
-        db.photos_map.remove({});
+        db.photos_map.deleteMany({});
 
         print('Start to fill conveyer for ' + db.photos.countDocument({ s: 5, type: 1, geo: { $exists: true } }) + ' photos');
         db.photos
@@ -278,7 +278,7 @@ waitDb.then(db => {
             });
 
         print('Clearing paintings map collection');
-        db.paintings_map.remove({});
+        db.paintings_map.deleteMany({});
         print('Start to fill conveyer for ' + db.photos.countDocuments({ s: 5, type: 2, geo: { $exists: true } }) + ' paintings');
         db.photos
             .find({ s: 5, type: 2, geo: { $exists: true } }, {
@@ -1104,7 +1104,7 @@ waitDb.then(db => {
             print('Heads up, removing ' + queueLength + ' queue items');
 
             // Delete photos stat queue first
-            db.region_stat_queue.remove({});
+            db.region_stat_queue.deleteMany({});
         }
 
         var changeCounter = 0;

--- a/controllers/systemjs.js
+++ b/controllers/systemjs.js
@@ -92,7 +92,7 @@ waitDb.then(db => {
         var clusterparamsQuery = { sgeo: { $exists: false } };
         var clusterZooms;
         var clusterZoomsCounter = -1;
-        var photosAllCount = db.photos.count({ s: 5, geo: { $exists: true } });
+        var photosAllCount = db.photos.countDocuments({ s: 5, geo: { $exists: true } });
 
         if (zooms) {
             clusterparamsQuery.z = { $in: zooms };
@@ -242,7 +242,7 @@ waitDb.then(db => {
         return {
             message: 'Ok in ' + (Date.now() - startFullTime) / 1000 + 's',
             photos: photosAllCount,
-            clusters: db.clusters.count(),
+            clusters: db.clusters.estimatedDocumentCount(),
         };
     });
 
@@ -252,7 +252,7 @@ waitDb.then(db => {
         print('Clearing photos map collection');
         db.photos_map.remove({});
 
-        print('Start to fill conveyer for ' + db.photos.count({ s: 5, type: 1, geo: { $exists: true } }) + ' photos');
+        print('Start to fill conveyer for ' + db.photos.countDocument({ s: 5, type: 1, geo: { $exists: true } }) + ' photos');
         db.photos
             .find({ s: 5, type: 1, geo: { $exists: true } }, {
                 _id: 0,
@@ -279,7 +279,7 @@ waitDb.then(db => {
 
         print('Clearing paintings map collection');
         db.paintings_map.remove({});
-        print('Start to fill conveyer for ' + db.photos.count({ s: 5, type: 2, geo: { $exists: true } }) + ' paintings');
+        print('Start to fill conveyer for ' + db.photos.countDocuments({ s: 5, type: 2, geo: { $exists: true } }) + ' paintings');
         db.photos
             .find({ s: 5, type: 2, geo: { $exists: true } }, {
                 _id: 0,
@@ -304,7 +304,7 @@ waitDb.then(db => {
                 });
             });
 
-        return { message: db.photos_map.count() + db.paintings_map.count() + ' photos to map added in ' + (Date.now() - startTime) / 1000 + 's' };
+        return { message: db.photos_map.estimatedDocumentCount() + db.paintings_map.estimatedDocumentCount() + ' photos to map added in ' + (Date.now() - startTime) / 1000 + 's' };
     });
 
     saveSystemJSFunc(function convertPhotosAll(params) {
@@ -354,7 +354,7 @@ waitDb.then(db => {
             query.s = { $in: params.statuses };
         }
 
-        print('Start to fill conveyer for ' + (query.user ? query.user + ' user for ' : '') + db.photos.count(query) + ' photos');
+        print('Start to fill conveyer for ' + (query.user ? query.user + ' user for ' : '') + db.photos.countDocuments(query) + ' photos');
         db.photos.find(query, selectFields).sort({ cid: 1 }).forEach(photo => {
             var row;
 
@@ -412,7 +412,7 @@ waitDb.then(db => {
 
             query.parents = { $size: level };
 
-            print('Starting objects assignment to ' + db.regions.count(query) + ' regions at ' + level + 'th level...');
+            print('Starting objects assignment to ' + db.regions.countDocuments(query) + ' regions at ' + level + 'th level...');
             db.regions.find(query, { _id: 0, cid: 1, parents: 1, geo: 1, title_en: 1 }).forEach(region => {
                 var startTime = Date.now();
                 var query = { geo: { $geoWithin: { $geometry: region.geo } } };
@@ -494,9 +494,9 @@ waitDb.then(db => {
 
         var counter = 0;
         var counterUpdated = 0;
-        var count = db.photos.count(query);
+        var count = db.photos.countDocuments(query);
 
-        print('Starting iteration over ' + db.photos.count(query) + ' photos..');
+        print('Starting iteration over ' + db.photos.countDocuments(query) + ' photos..');
         db.photos.find(query, fields).sort({ cid: 1 }).forEach(photo => {
             var regions = db.regions.find(
                 { geo: { $nearSphere: { $geometry: { type: 'Point', coordinates: photo.geo }, $maxDistance: 1 } } },
@@ -558,7 +558,7 @@ waitDb.then(db => {
         var photoCounter = 0;
         var maxRegionLevel = 5;
 
-        print('Assign regions to comments for ' + db.photos.count({ s: { $gte: 5 } }) + ' published photos');
+        print('Assign regions to comments for ' + db.photos.countDocuments({ s: { $gte: 5 } }) + ' published photos');
         db.photos.find(
             { s: { $gte: 5 } }, { _id: 1, geo: 1, r0: 1, r1: 1, r2: 1, r3: 1, r4: 1, r5: 1 }
         ).forEach(photo => {
@@ -627,7 +627,7 @@ waitDb.then(db => {
             ];
         }
 
-        print('Start to calc center for ' + db.regions.count(query) + ' regions..\n');
+        print('Start to calc center for ' + db.regions.countDocuments(query) + ' regions..\n');
         db.regions.find(query, { _id: 0, cid: 1, geo: 1, bbox: 1 }).forEach(region => {
             if (region.geo && (region.geo.type === 'MultiPolygon' || region.geo.type === 'Polygon')) {
                 db.regions.update({ cid: region.cid }, {
@@ -679,7 +679,7 @@ waitDb.then(db => {
         var startTime = Date.now();
         var query = { cid: { $ne: 1000000 } };
 
-        print('Start to calc bbox for ' + db.regions.count(query) + ' regions..\n');
+        print('Start to calc bbox for ' + db.regions.countDocuments(query) + ' regions..\n');
         db.regions.find(query, { _id: 0, cid: 1, geo: 1 }).forEach(region => {
             if (region.geo && (region.geo.type === 'MultiPolygon' || region.geo.type === 'Polygon')) {
                 db.regions.update({ cid: region.cid }, { $set: { bbox: polyBBOX(region.geo).map(toPrecision6) } });
@@ -787,7 +787,7 @@ waitDb.then(db => {
             return previousValue + (Array.isArray(currentValue[0]) ? currentValue.reduce(calcGeoJSONPointsNumReduce, 0) : 1);
         }
 
-        print('Start to calculate points number for ' + db.regions.count(query) + ' regions..\n');
+        print('Start to calculate points number for ' + db.regions.countDocuments(query) + ' regions..\n');
         db.regions.find(query, { cid: 1, geo: 1, title_en: 1 }).sort({ cid: 1 }).forEach(region => {
             var startTime = Date.now();
             var count;
@@ -811,7 +811,7 @@ waitDb.then(db => {
             query.cid = cidArr.length === 1 ? cidArr[0] : { $in: cidArr };
         }
 
-        print('Start to calculate polynum for ' + db.regions.count(query) + ' regions..\n');
+        print('Start to calculate polynum for ' + db.regions.countDocuments(query) + ' regions..\n');
         db.regions.find(query, { cid: 1, geo: 1, title_en: 1 }).sort({ cid: 1 }).forEach(region => {
             var polynum;
 
@@ -876,7 +876,7 @@ waitDb.then(db => {
         var counter = 0;
         var renamedCounter = 0;
 
-        print('Start for ' + db.regions.count() + ' regions..\n');
+        print('Start for ' + db.regions.estimatedDocumentCount() + ' regions..\n');
         db.regions.find({}, { _id: 0, title_en: 1, title_local: 1 }).sort({ cid: 1 }).forEach(region => {
             renamedCounter += regionClearPhotoTitle([region.title_en, region.title_local]).count;
 
@@ -919,11 +919,11 @@ waitDb.then(db => {
             $set = {};
             $unset = {};
             $update = {};
-            pcount = db.photos.count({ user: user._id, s: 5 });
-            pfcount = db.photos.count({ user: user._id, s: { $in: [0, 1, 2] } });
-            pdcount = db.photos.count({ user: user._id, s: { $in: [3, 4, 7, 9] } });
-            ccount = db.comments.count({ user: user._id, del: null }) +
-                     db.commentsn.count({ user: user._id, del: null });
+            pcount = db.photos.countDocuments({ user: user._id, s: 5 });
+            pfcount = db.photos.countDocuments({ user: user._id, s: { $in: [0, 1, 2] } });
+            pdcount = db.photos.countDocuments({ user: user._id, s: { $in: [3, 4, 7, 9] } });
+            ccount = db.comments.countDocuments({ user: user._id, del: null }) +
+                     db.commentsn.countDocuments({ user: user._id, del: null });
 
             if (pcount > 0) {
                 $set.pcount = pcount;
@@ -981,7 +981,7 @@ waitDb.then(db => {
             query.obj = objId;
         }
 
-        print('0s Start to calc for ' + db.users_objects_rel.count(query) + ' rels');
+        print('0s Start to calc for ' + db.users_objects_rel.countDocuments(query) + ' rels');
         db.users_objects_rel.find(query).sort({ user: 1 }).forEach(rel => {
             counter += 1;
 
@@ -994,7 +994,7 @@ waitDb.then(db => {
                     rel.ccount_new = 0;
                 }
 
-                ccountNew = commentCollection.count({
+                ccountNew = commentCollection.countDocuments({
                     obj: rel.obj,
                     del: null,
                     stamp: { $gt: rel.comments },
@@ -1052,7 +1052,7 @@ waitDb.then(db => {
             $set = {};
             $unset = {};
             $update = {};
-            ccount = db.comments.count({ obj: photo._id, del: null });
+            ccount = db.comments.countDocuments({ obj: photo._id, del: null });
 
             if (ccount > 0) {
                 $set.ccount = ccount;
@@ -1060,7 +1060,7 @@ waitDb.then(db => {
                 $unset.ccount = 1;
             }
 
-            cdcount = db.comments.count({ obj: photo._id, del: { $exists: true } });
+            cdcount = db.comments.countDocuments({ obj: photo._id, del: { $exists: true } });
 
             if (cdcount > 0) {
                 $set.cdcount = cdcount;
@@ -1098,7 +1098,7 @@ waitDb.then(db => {
             query.cid = { $in: cids };
         }
 
-        const queueLength = db.region_stat_queue.count({});
+        const queueLength = db.region_stat_queue.estimatedDocumentCount();
 
         if (queueLength) {
             print('Heads up, removing ' + queueLength + ' queue items');
@@ -1127,12 +1127,12 @@ waitDb.then(db => {
             return changedSomething;
         }
 
-        var count = db.regions.count(query);
+        var count = db.regions.countDocuments(query);
 
         print('Starting stat calculation for ' + count + ' regions');
         db.regions.find(query, fields).sort({ cid: 1 }).forEach(region => {
             var level = region.parents && region.parents.length || 0;
-            var regionHasChildren = db.regions.count({ parents: region.cid }) > 0;
+            var regionHasChildren = db.regions.countDocuments({ parents: region.cid }) > 0;
 
             var queryC = { del: null };
             var queryImage = {};
@@ -1187,11 +1187,11 @@ waitDb.then(db => {
                 photos.statuses.forEach(status => {
                     $update.photostat['s' + status.s] = status.count;
                 });
-                $update.photostat.geo = db.photos.count((queryPhoto.geo = { $exists: true }, queryPhoto));
+                $update.photostat.geo = db.photos.countDocuments((queryPhoto.geo = { $exists: true }, queryPhoto));
 
                 if (regionHasChildren) {
-                    $update.photostat.owngeo = db.photos.count((queryPhoto['r' + (level + 1)] = null, queryPhoto));
-                    $update.photostat.own = db.photos.count((delete queryPhoto.geo, queryPhoto));
+                    $update.photostat.owngeo = db.photos.countDocuments((queryPhoto['r' + (level + 1)] = null, queryPhoto));
+                    $update.photostat.own = db.photos.countDocuments((delete queryPhoto.geo, queryPhoto));
                 } else {
                     $update.photostat.owngeo = $update.photostat.geo;
                     $update.photostat.own = $update.photostat.all;
@@ -1203,21 +1203,21 @@ waitDb.then(db => {
                 paintings.statuses.forEach(status => {
                     $update.paintstat['s' + status.s] = status.count;
                 });
-                $update.paintstat.geo = db.photos.count((queryPaint.geo = { $exists: true }, queryPaint));
+                $update.paintstat.geo = db.photos.countDocuments((queryPaint.geo = { $exists: true }, queryPaint));
 
                 if (regionHasChildren) {
-                    $update.paintstat.owngeo = db.photos.count((queryPaint['r' + (level + 1)] = null, queryPaint));
-                    $update.paintstat.own = db.photos.count((delete queryPaint.geo, queryPaint));
+                    $update.paintstat.owngeo = db.photos.countDocuments((queryPaint['r' + (level + 1)] = null, queryPaint));
+                    $update.paintstat.own = db.photos.countDocuments((delete queryPaint.geo, queryPaint));
                 } else {
                     $update.paintstat.owngeo = $update.paintstat.geo;
                     $update.paintstat.own = $update.paintstat.all;
                 }
             }
 
-            $update.cstat.s5 = db.comments.count((queryC.s = 5, queryC));
-            $update.cstat.s7 = db.comments.count((queryC.s = 7, queryC));
-            $update.cstat.s9 = db.comments.count((queryC.s = 9, queryC));
-            $update.cstat.del = db.comments.count((delete queryC.s, queryC.del = { $exists: true }, queryC));
+            $update.cstat.s5 = db.comments.countDocuments((queryC.s = 5, queryC));
+            $update.cstat.s7 = db.comments.countDocuments((queryC.s = 7, queryC));
+            $update.cstat.s9 = db.comments.countDocuments((queryC.s = 9, queryC));
+            $update.cstat.del = db.comments.countDocuments((delete queryC.s, queryC.del = { $exists: true }, queryC));
             $update.cstat.all = $update.cstat.s5 + $update.cstat.s7 + $update.cstat.s9 + $update.cstat.del;
 
             db.regions.update({ cid: region.cid }, { $set: $update });

--- a/controllers/userobjectrel.js
+++ b/controllers/userobjectrel.js
@@ -122,7 +122,7 @@ export async function setCommentView(objId, userId, type = 'photo', stamp = new 
         }
     }
 
-    await UserObjectRel.update(query, update, { upsert: true }).exec();
+    await UserObjectRel.updateOne(query, update, { upsert: true }).exec();
 
     return relBeforeUpdate;
 }
@@ -134,10 +134,9 @@ export async function setCommentView(objId, userId, type = 'photo', stamp = new 
  * @param {string} [type=photo] Object type
  */
 export async function onCommentAdd(objId, userId, type = 'photo') {
-    const { n: count = 0 } = await UserObjectRel.update(
+    const { n: count = 0 } = await UserObjectRel.updateMany(
         { obj: objId, comments: { $exists: true }, user: { $ne: userId }, type },
-        { $inc: { ccount_new: 1 } },
-        { multi: true }
+        { $inc: { ccount_new: 1 } }
     ).exec();
 
     return count;
@@ -192,7 +191,7 @@ export async function onCommentsRemove(objId, comments, type = 'photo') {
 
             // Update specific rel, but just in case но на всякий случае specify maximum time of comments view,
             // on which we compute, in case while we compete user read comments again
-            result.push(UserObjectRel.update(
+            result.push(UserObjectRel.updateOne(
                 { _id: rel._id, comments: { $lte: lastCommentStamp } },
                 { $inc: { ccount_new: -newDeltaCount } }
             ).exec());
@@ -247,7 +246,7 @@ export async function onCommentsRestore(objId, comments, type = 'photo') {
         }, 0);
 
         if (newDeltaCount) {
-            result.push(UserObjectRel.update(
+            result.push(UserObjectRel.updateOne(
                 // Обновляем конкретный rel, но на всякий случае указываем максимальное время просмотра комментариев,
                 // по которому мы считали, на случай, если пока мы считали пользователь опять посмотрел комментарии
                 { _id: rel._id, comments: { $lte: lastCommentStamp } },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   mongo:
-    image: pastvu/mongo:3.2.22
+    image: mongo:4.4
     volumes:
       - mongo:/data/db
     expose:

--- a/models/User.js
+++ b/models/User.js
@@ -129,7 +129,7 @@ registerModel(db => {
     UserScheme.methods.incLoginAttempts = function () {
         // If we have a previous lock that has expired, restart at 1
         if (this.lockUntil && this.lockUntil < Date.now()) {
-            return this.update({ $set: { loginAttempts: 1 }, $unset: { lockUntil: 1 } }).exec();
+            return this.updateOne({ $set: { loginAttempts: 1 }, $unset: { lockUntil: 1 } }).exec();
         }
 
         // Otherwise we're incrementing
@@ -140,7 +140,7 @@ registerModel(db => {
             updates.$set = { lockUntil: Date.now() + LOCK_TIME };
         }
 
-        return this.update(updates).exec();
+        return this.updateOne(updates).exec();
     };
 
     UserScheme.statics.getAuthenticated = async function (login, password) {

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -16,7 +16,7 @@ mongoose.Query.prototype.paginate = function paginate(page, limit, cb) {
                 cb(err, null, null);
             } else {
                 // eslint-disable-next-line no-underscore-dangle
-                model.count(query._conditions, (err, total) => {
+                model.countDocuments(query._conditions, (err, total) => {
                     if (err) {
                         cb(err, null, null);
                     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3221,6 +3221,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
             "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+            "dev": true,
             "requires": {
                 "lodash": "^4.14.0"
             }
@@ -3385,9 +3386,9 @@
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
         },
         "bluebird": {
-            "version": "2.10.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-            "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "body-parser": {
             "version": "1.19.0",
@@ -3439,9 +3440,9 @@
             }
         },
         "bson": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-            "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+            "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         },
         "buffer": {
             "version": "4.9.1",
@@ -3485,11 +3486,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "buffer-shims": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
         "bufferutil": {
             "version": "4.0.1",
@@ -4129,6 +4125,11 @@
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
+        "denque": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+            "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+        },
         "density-clustering": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
@@ -4348,11 +4349,6 @@
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
-        },
-        "es6-promise": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-            "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "escalade": {
             "version": "3.1.1",
@@ -6134,11 +6130,6 @@
             "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
             "dev": true
         },
-        "hooks-fixed": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
-            "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
-        },
         "hosted-git-info": {
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
@@ -6755,9 +6746,9 @@
             }
         },
         "kareem": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
-            "integrity": "sha1-7XYgAET6BB7zK02oJh4lU/EXNTE="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+            "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
         },
         "kind-of": {
             "version": "3.2.2",
@@ -7403,6 +7394,12 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
+        "memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
         "meow": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -7528,78 +7525,58 @@
             "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "mongodb": {
-            "version": "2.2.26",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.26.tgz",
-            "integrity": "sha1-G9UMVXwnfJjhoF2jjJg5xJIrA0o=",
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+            "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
             "requires": {
-                "es6-promise": "3.2.1",
-                "mongodb-core": "2.1.10",
-                "readable-stream": "2.2.7"
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
+                "require_optional": "^1.0.1",
+                "safe-buffer": "^5.1.2",
+                "saslprep": "^1.0.0"
             },
             "dependencies": {
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                },
-                "readable-stream": {
-                    "version": "2.2.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-                    "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+                "bl": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+                    "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
                     "requires": {
-                        "buffer-shims": "~1.0.0",
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~1.0.0",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "readable-stream": "^2.3.5",
+                        "safe-buffer": "^5.1.1"
                     }
                 }
-            }
-        },
-        "mongodb-core": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.10.tgz",
-            "integrity": "sha1-6ykGgdGW0zRqSSFhqi6gkF5jFRs=",
-            "requires": {
-                "bson": "~1.0.4",
-                "require_optional": "~1.0.0"
             }
         },
         "mongoose": {
-            "version": "4.9.9",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.9.9.tgz",
-            "integrity": "sha1-hnH74GyUX1X7p60DeXvALxlRZ2I=",
+            "version": "5.10.15",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.15.tgz",
+            "integrity": "sha512-3QUWCpMRdFCPIBZkjG/B2OkfMY2WLkR+hv335o4T2mn3ta9kx8qVvXeUDojp3OHMxBZVUyCA+hDyyP4/aKmHuA==",
             "requires": {
-                "async": "2.1.4",
-                "bson": "~1.0.4",
-                "hooks-fixed": "2.0.0",
-                "kareem": "1.4.1",
-                "mongodb": "2.2.26",
-                "mpath": "0.2.1",
-                "mpromise": "0.5.5",
-                "mquery": "2.3.0",
-                "ms": "0.7.2",
-                "muri": "1.2.1",
-                "regexp-clone": "0.0.1",
+                "bson": "^1.1.4",
+                "kareem": "2.3.1",
+                "mongodb": "3.6.3",
+                "mongoose-legacy-pluralize": "1.0.2",
+                "mpath": "0.7.0",
+                "mquery": "3.2.2",
+                "ms": "2.1.2",
+                "regexp-clone": "1.0.0",
+                "safe-buffer": "5.2.1",
+                "sift": "7.0.1",
                 "sliced": "1.0.1"
             },
             "dependencies": {
-                "ms": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
+        },
+        "mongoose-legacy-pluralize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+            "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
         },
         "monotone-convex-hull-2d": {
             "version": "1.0.1",
@@ -7610,43 +7587,34 @@
             }
         },
         "mpath": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
-            "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
-        },
-        "mpromise": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
-            "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+            "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
         },
         "mquery": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.0.tgz",
-            "integrity": "sha1-PRcXrYlY0MmeQuokYaEJ8+Xz5Fg=",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+            "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
             "requires": {
-                "bluebird": "2.10.2",
-                "debug": "2.2.0",
-                "regexp-clone": "0.0.1",
-                "sliced": "0.0.5"
+                "bluebird": "3.5.1",
+                "debug": "3.1.0",
+                "regexp-clone": "^1.0.0",
+                "safe-buffer": "5.1.2",
+                "sliced": "1.0.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
                     }
                 },
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                },
-                "sliced": {
-                    "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-                    "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -7654,11 +7622,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "muri": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
-            "integrity": "sha1-7H6lzmympSPrGrNbrNpfqBbJqjw="
         },
         "mute-stream": {
             "version": "0.0.8",
@@ -8631,9 +8594,9 @@
             "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regexp-clone": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
-            "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+            "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
         },
         "regexp.prototype.flags": {
             "version": "1.3.0",
@@ -8838,6 +8801,15 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+        "saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "requires": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -9033,6 +9005,11 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
+        },
+        "sift": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+            "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -9261,6 +9238,15 @@
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+            "optional": true,
+            "requires": {
+                "memory-pager": "^1.0.2"
             }
         },
         "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "make-dir": "3.0.0",
         "mime": "2.4.4",
         "moment": "2.24.0",
-        "mongoose": "4.9.9",
+        "mongoose": "5.10.15",
         "ms": "2.1.2",
         "mv": "2.1.1",
         "nodemailer": "6.4.2",


### PR DESCRIPTION
### What is included
This patch-set includes a first part of changes required for migration to MongoDB 4:

* Updating Mongoose 4.9.9 -> 5.10.15  cf64677
* Docker-compose and Readme update to use MongoDB 4.4 8970f26

* Mongodb connection instance changes for Mongoose 5.x  29e0fa9

  This includes adding new connection that adjust Mongoose behaviour to latest MongoDB API driver requirement:
  * `useUnifiedTopology: true` Use new topology engine (since MongoDB API driver 3.3) [more...](https://mongoosejs.com/docs/deprecations.html#useUnifiedTopology)
  * `useNewUrlParser: true` Use new connection string parser [more...](https://mongoosejs.com/docs/deprecations.html#useNewUrlParser)
  * `useCreateIndex: true` Use createIndex internally (`ensureIndex` is deprecated in MongoDB API driver 3.2) [more...](https://mongoosejs.com/docs/deprecations.html#useCreateIndex)
  * `useFindAndModify: false` Use findOneAndUpdate interally (`findAndModify` is deprecated in MongoDB API driver 3.1) [more...](https://mongoosejs.com/docs/deprecations.html#useFindAndModify)

  Also this includes options declaration changes [more...](https://mongoosejs.com/docs/connections.html#v5-changes)

* Replace deprecated `count()` with alternatives. 383226a
  As of MongoDB driver 3.1 `count()` is [deprecated](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#count)
  Using `countDocuments()` or fast alternative `estimatedDocumentCount()` where applicable [more...](https://mongoosejs.com/docs/deprecations.html#count)

* Replace deprecated `remove()` with alternatives d1e2403
  As of MongoDB driver 3.1 `remove()` is [deprecated](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#remove)
  Using `deleteOne` and `deleteMany` depending on context [more...](https://mongoosejs.com/docs/deprecations.html#remove)
  Also addressed API change in returned object format when applied to query. 

* Replace deprecated `update()` with alternatives a34f81f
  As of MongoDB driver 3.1 `update()` is [deprecated](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#update)
  Using `updateOne` and `updateMany` depending on context [more...](https://mongoosejs.com/docs/deprecations.html#update)

* Replace deprecated `insert()` with alternatives 5c9ad53
  As of MongoDB driver 3.1 `insert()` is [deprecated](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insert)
  Using `insertOne` and `insertMany` depending on context.

* Code is also checked for presence of other operators not compatible with current version.

Additional sources used for this work:
https://github.com/Automattic/mongoose/blob/master/History.md#500-rc0--2017-12-28
https://mongoosejs.com/docs/migrating_to_5.html

At this point, app is working with no errors or deprecation warnings (apart of those listed in TODO below). I tested a number of different use cases that came to my mind (all common user actions with photos, profile, comments, conversion, clusters generations), though it still needs thorough testing on staging (or on dedicated instance for this change).

There are some todo tasks are left (if this one is merged, they will come as separate PRs, otherwise patches will be added to this branch).

### TODO

1. We are using `db.eval()` here:
https://github.com/PastVu/pastvu/blob/master/controllers/connection.js#L98
This [has been deprecated](https://mongodb.github.io/node-mongodb-native/3.1/api/Db.html#eval) with no replacement alternative, so parts where we use it needs to be re-written. For more info why it has been removed, see https://jira.mongodb.org/browse/SERVER-17453 

2. On staring the app I am getting `DeprecationWarning: collection.save is deprecated.` message coming from MongoDB driver API, it is caused by this line:
https://github.com/PastVu/pastvu/blob/master/controllers/systemjs.js#L27
If I am replacing that with `insertOne` ([per API docs](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#save)), I start getting same deprecation warnings coming from `basepatch/v1.3.0.7.js` that got similar use of `collection.save()`. I am not sure if that is correct, may be @klimashkin can explain why it is pulling patches (or is it supposed to, in that case patches need code changes too)?

3. As discussed https://github.com/PastVu/pastvu/issues/191#issuecomment-729706528, it might be a good idea to convert indexes from [`2d`](https://docs.mongodb.com/manual/core/2d/) to [`2dsphere`](https://docs.mongodb.com/manual/core/2dsphere/), so we can use [geospacial queries](https://docs.mongodb.com/manual/geospatial-queries/#id1) in full where required.