### PR TITLE
Implement graceful shutdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import connectDb, { waitDb } from './controllers/connection';
 import * as session from './controllers/_session';
 import CoreServer from './controllers/serviceConnector';
 import { handleSocketConnection, registerSocketRequestHendler } from './app/request';
+import exitHook from 'async-exit-hook';
 
 import { photosReady } from './controllers/photo';
 import { ready as mailReady } from './controllers/mail';
@@ -305,6 +306,11 @@ export async function configure(startStamp) {
         );
 
         scheduleMemInfo(startStamp - Date.now());
+    });
+
+    exitHook(cb => {
+        logger.info('HTTP server is shutting down');
+        httpServer.close(cb);
     });
 
     // Once db is connected, start some periodic jobs.

--- a/controllers/serviceConnector.js
+++ b/controllers/serviceConnector.js
@@ -1,5 +1,6 @@
 import net from 'net';
 import { handleServiceRequest } from '../app/request';
+import exitHook from 'async-exit-hook';
 
 class ClientSocket {
     constructor(server, socket, logger) {
@@ -110,6 +111,11 @@ export default class Server {
                 });
 
             this.logger.info(`${this.name} client connected. Total clients: ${this.clientSockets.length}`);
+        });
+
+        exitHook(cb => {
+            this.logger.info(`${this.name} server is shutting down`);
+            this.server.close(cb);
         });
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - .:/code
       - store:/store
-    command: npm run app
+    command: run app
 
   notifier:
     << : *app-image
@@ -42,7 +42,7 @@ services:
       - NOTIFIER=true
     volumes:
       - .:/code
-    command: npm run notifier
+    command: run notifier
 
   uploader:
     << : *app-image
@@ -53,7 +53,7 @@ services:
     volumes:
       - .:/code
       - store:/store
-    command: npm run uploader
+    command: run uploader
 
   downloader:
     << : *app-image
@@ -64,7 +64,7 @@ services:
     volumes:
       - .:/code
       - store:/store:ro
-    command: npm run downloader
+    command: run downloader
 
   sitemap:
     << : *app-image
@@ -73,7 +73,7 @@ services:
     volumes:
       - .:/code
       - sitemap:/sitemap
-    command: npm run sitemap
+    command: run sitemap
 
   mailcatcher:
     image: sj26/mailcatcher:latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "pastvu",
             "version": "1.3.8",
             "dependencies": {
                 "@mapbox/geojson-area": "0.2.2",
                 "@mapbox/geojsonhint": "3.0.0",
                 "@turf/intersect": "6.1.3",
                 "@turf/turf": "5.1.6",
+                "async-exit-hook": "2.0.1",
                 "aws-sdk": "2.610.0",
                 "basic-auth-connect": "1.0.0",
                 "bcrypt": "5.0.0",
@@ -3095,6 +3097,14 @@
             "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
+            }
+        },
+        "node_modules/async-exit-hook": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+            "engines": {
+                "node": ">=0.12.0"
             }
         },
         "node_modules/async-limiter": {
@@ -14760,6 +14770,11 @@
             "requires": {
                 "lodash": "^4.17.14"
             }
+        },
+        "async-exit-hook": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw=="
         },
         "async-limiter": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@mapbox/geojsonhint": "3.0.0",
         "@turf/intersect": "6.1.3",
         "@turf/turf": "5.1.6",
+        "async-exit-hook": "2.0.1",
         "aws-sdk": "2.610.0",
         "basic-auth-connect": "1.0.0",
         "bcrypt": "5.0.0",

--- a/uploader.js
+++ b/uploader.js
@@ -9,6 +9,7 @@ import log4js from 'log4js';
 import config from './config';
 import formidable from 'formidable';
 import Utils from './commons/Utils';
+import exitHook from 'async-exit-hook';
 
 export function configure(startStamp) {
     const {
@@ -286,10 +287,15 @@ export function configure(startStamp) {
         }
     };
 
-    http.createServer(handleRequest).listen(listenport, '0.0.0.0', () => {
+    const server = http.createServer(handleRequest).listen(listenport, '0.0.0.0', () => {
         logger.info(
             `Uploader server started up in ${(Date.now() - startStamp) / 1000}s`,
             `and listening [*:${listenport}]\n`
         );
+    });
+
+    exitHook(cb => {
+        logger.info('Uploader server is shutting down');
+        server.close(cb);
     });
 }


### PR DESCRIPTION
Gracefully stop all clients and services when application is about to stop.

Adds [async-exit-hook](https://github.com/Tapppi/async-exit-hook) module that will trigger registered hooks on relevant system signals or `process.exit` event.

This PR depends on image change that needs to be merged first (and image needs to be built following that): https://github.com/PastVu/node/pull/1

