### PR TITLE
Fix photo.giveObjHist error on photo change history listing

### DIFF
--- a/controllers/region.js
+++ b/controllers/region.js
@@ -205,27 +205,37 @@ export const getRegionsArrFromHash = (hash, cids) => {
 
     return result;
 };
-export const fillRegionsHash = (hash, fileds) => {
-    if (fileds) {
-        // hash is a null prototype object
-        for (const i in hash) { // eslint-disable-line guard-for-in
-            const region = regionCacheHash[i];
 
-            hash[i] = {};
+/**
+ * Returns regions array in the same order as received array of cids
+ *
+ * @param {object[]} hash Array containing region cids as keys.
+ * @param {Array} [fields] Populate hash object with specified fields values only.
+ */
+export const fillRegionsHash = (hash, fields) => {
+    // hash is a null prototype object
+    for (const i in hash) { // eslint-disable-line guard-for-in
+        hash[i] = {};
 
-            for (const field of fileds) {
+        const region = regionCacheHash[i];
+
+        if (region === undefined) {
+            // It is likely the region was deleted, skip it.
+            continue;
+        }
+
+        if (fields.length) {
+            for (const field of fields) {
                 hash[i][field] = region[field];
             }
-        }
-    } else {
-        // hash is a null prototype object
-        for (const i in hash) { // eslint-disable-line guard-for-in
-            hash[i] = regionCacheHash[i];
+        } else {
+            hash[i] = region;
         }
     }
 
     return hash;
 };
+
 export const fillRegionsPublicStats = regions => {
     if (regions) {
         for (const region of regions) {

--- a/public/js/module/photo/hist.js
+++ b/public/js/module/photo/hist.js
@@ -190,7 +190,9 @@ define(
                             regionsAdd = [];
 
                             for (j = 0; j < regionCids.length; j++) {
-                                regionsArr.push(regionsHash[regionCids[j]]);
+                                if (!_.isEmpty(regionsHash[regionCids[j]])) {
+                                    regionsArr.push(regionsHash[regionCids[j]]);
+                                }
                             }
 
                             if (showDiff && regionsPrev) {


### PR DESCRIPTION
The error described in #359 was caused by non-existing region reference in `photos_history` collection.

The patch defaults deleted region item to empty object when it is populated using `fillRegionsHash` function. If left as is after this change, missing region in history will be shown as "undefined":
![undef1](https://user-images.githubusercontent.com/329780/116147014-14ad1900-a6d7-11eb-9d95-b675773d1937.png)
![undef](https://user-images.githubusercontent.com/329780/116147048-22fb3500-a6d7-11eb-8e65-f313e6b946e5.png)

This has been elaborated further to skip missing region item from listing for simplicity (parent or child
regions will be shown as normal):
![image](https://user-images.githubusercontent.com/329780/116147385-92712480-a6d7-11eb-9d84-0c3b982560cc.png)
![image](https://user-images.githubusercontent.com/329780/116147477-addc2f80-a6d7-11eb-806d-93be271554d6.png)

If that is not what expected in UI, it is possible to leave deleted region listed as "undefined" (or use better wording). It is not possible though to identify what the title of the deleted region was.

Notice that only client listing of photo history is affected. Regions defined in `photos` record are updated correctly when region is deleted (normally moved to parent region).