### PR TITLE
Use magneta color for "ready for publish" photo status icon

### DIFF
--- a/public/js/module/appAdmin.js
+++ b/public/js/module/appAdmin.js
@@ -12,8 +12,7 @@ require([
 
     Utils.title.setPostfix('Администрирование - Фотографии прошлого');
 
-    var appHash = P.settings.hash(),
-        routerDeferred = $.Deferred(),
+    var routerDeferred = $.Deferred(),
         routerAnatomy = {
             globalModules: {
                 modules: [
@@ -149,5 +148,5 @@ require([
 
     //window.appRouter = globalVM.router;
     //window.glob = globalVM;
-    console.log('APP %s loaded', appHash);
+    console.log('APP %s loaded', P.settings.version());
 });

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -10,7 +10,6 @@ require([
 
     Utils.title.setPostfix('Фотографии прошлого');
 
-    var appHash = P.settings.hash();
     var routerDeferred = $.Deferred();
     var routerAnatomy = {
         globalModules: {
@@ -172,9 +171,12 @@ require([
     globalVM.router = router.init(routerAnatomy);
     $.when(routerDeferred.promise()).then(function () {
         router.start();
+        // App info in console.
+        const style = `color: #204A6B; font-family:monospace; background: url(${location.origin}/favicon.ico) left/contain no-repeat; padding-left: 10px`;
+        const string = `PastVu App v${P.settings.version()} loaded. Bug reports and contribs are welcome at https://github.com/PastVu/pastvu`;
+        console.log("%c " + string, style);
     });
 
     // window.appRouter = globalVM.router;
     // window.glob = globalVM;
-    console.log('APP %s loaded', appHash);
 });

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -903,13 +903,26 @@ body {
 			bottom: 4px;
 			left: 2px;
 			text-align: center;
-
+			> .glyphicon {
+				top: 0px;
+                                font-size: 96%;
+			}
 			> .glyphicon-lock {
-				left: 1px;
+				left: 0.5px;
 			}
 		}
 
-		&.s0, &.s2 {
+		&.s0 {
+			border-color: #AA00FF;
+			.status {
+				background-color: #AA00FF;
+			}
+			&.withInfo > .info::after {
+				background: #AA00FF;
+				background: linear-gradient(to right, rgba(40, 89, 145, .3) 0%, rgba(102, 173, 104, .8) 12%, #AA00FF 50%, rgba(102, 173, 104, .8) 88%, rgba(40, 89, 145, .3) 100%);
+			}
+		}
+	        &.s2 {
 			border-color: rgb(114, 193, 116);
 			.status {
 				background-color: rgb(3, 168, 28);
@@ -919,7 +932,7 @@ body {
 				background: linear-gradient(to right, rgba(40, 89, 145, .3) 0%, rgba(102, 173, 104, .8) 12%, #96FF96 50%, rgba(102, 173, 104, .8) 88%, rgba(40, 89, 145, .3) 100%);
 			}
 		}
-		&.s3 {
+                &.s3 {
 			border-color: #8B8B8B;
 			.status {
 				background-color: #8B8B8B;


### PR DESCRIPTION
This is addressing #353 by replacing color for "ready for publish" photo status with `#AA00FF`. This patch also makes icon position within borders more central.

**BEFORE**:
![background](https://user-images.githubusercontent.com/329780/116303719-ed6b5000-a799-11eb-93fa-e494de60239b.png)

**AFTER**:
![background1](https://user-images.githubusercontent.com/329780/116303954-fc520280-a799-11eb-8cf7-4081ad74dda0.png)

As a bonus, this patch enhances app info display at console, making it as follows:
![console](https://user-images.githubusercontent.com/329780/116304499-8ac68400-a79a-11eb-8d37-aff573b89b50.jpeg)

If any changes are required, please let me know.