### PR TITLE
MongoDB 4.x migration - Part 7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,6 +225,7 @@ module.exports = function (grunt) {
                         'models/**/*.js',
                         'config/!(local.config).js',
                         'config/*example',
+                        'migrations/*.js',
                         // Add here public/js/ files that have been modified
                         // in PRs, so we gradually get them all covered and
                         // then refactor into smaller list.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ docker-compose run -p 9229:9229 -p 3000:3000 app npm run inspect-brk
 In this case execution will stop at the first line of code, allowing you to
 run inspector client and control execution flow.
 
+### Database migrations
+
+We are using [`migrate-mongo`](https://github.com/seppevs/migrate-mongo) database migration tool. Its CLI commands have npm script alises for convenience of running in docker environment:
+
+* `migrate:create` - alias for `migrate-mongo create`
+* `migrate:status` - alias for `migrate-mongo status`
+* `migrate:up` - alias for `migrate-mongo up`
+* `migrate:down` - alias for `migrate-mongo down`
+* `migrate` - alias for `migrate:up` script
+
+When running in docker-compose environment use:
+
+```
+docker-compose run app npm run migrate:status
+```
+This will bring up all app dependencies (mongoDb container) and execute
+required command.
+
+In order to create new migration, run `migrate-mongo create
+<name_of_migration>`, this will create a file in `./migrations` directory
+which needs to be amended according to requirements. For examples please refer
+to existing migrations or `migrate-mongo` documentation.
+
 ### Troubleshooting
 
 If you are using docker inside VM and accessing app from host OS (or any other scenario where web client host may differ from the host where you run docker), make sure that `client.hostname` in your `config/local.config.js` is matching domain name that client uses to access the app. This setting is used for cookies domain, so having it wrong will result in session being cleared on page refresh.

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import express from 'express';
 import socketIO from 'socket.io';
 import Utils from './commons/Utils';
 import connectDb, { waitDb } from './controllers/connection';
+import { logPendingMigrations } from './controllers/migration';
 import * as session from './controllers/_session';
 import CoreServer from './controllers/serviceConnector';
 import { handleSocketConnection, registerSocketRequestHendler } from './app/request';
@@ -302,8 +303,7 @@ export async function configure(startStamp) {
         logger.info(
             `HTTP server started up in ${(Date.now() - startStamp) / 1000}s`,
             `and listening [${hostname || '*'}:${port}]`,
-            config.gzip ? 'with gzip' : '',
-            '\n'
+            config.gzip ? 'with gzip' : ''
         );
 
         scheduleMemInfo(startStamp - Date.now());
@@ -325,4 +325,6 @@ export async function configure(startStamp) {
 
         session.checkSessWaitingConnect();
     });
+
+    logPendingMigrations();
 }

--- a/config/log4js.js
+++ b/config/log4js.js
@@ -1,5 +1,5 @@
 /**
- * Module for generating log4js configuration.
+ * Log4js configuration.
  */
 
 const path = require('path');

--- a/config/migrate-mongo.js
+++ b/config/migrate-mongo.js
@@ -1,0 +1,18 @@
+/**
+ * Migrate-mongo configuration.
+ */
+const mongoConfig = require('./').mongo;
+
+const config = {
+    mongodb: {
+        url: mongoConfig.connection,
+        options: {
+            useNewUrlParser: true, // removes a deprecation warning when connecting
+            useUnifiedTopology: true, // removes a deprecating warning when connecting
+        },
+    },
+    migrationsDir: 'migrations',
+    changelogCollectionName: 'changelog',
+};
+
+module.exports = config;

--- a/config/migrate-mongo.js
+++ b/config/migrate-mongo.js
@@ -2,6 +2,15 @@
  * Migrate-mongo configuration.
  */
 const mongoConfig = require('./').mongo;
+const argv = require('yargs').argv;
+const logger = require('log4js').getLogger('migrate-mongo');
+
+// Replace node console with logger for up and down migration commands, so we have a
+// log record for these actions.
+if (argv._.includes('up') || argv._.includes('down')) {
+    console.log = logger.info.bind(logger);
+    console.error = logger.error.bind(logger);
+}
 
 const config = {
     mongodb: {

--- a/config/server.js
+++ b/config/server.js
@@ -78,6 +78,7 @@ module.exports = (function () {
 
     config.client.host = `${config.client.hostname}${config.client.port}`;
     config.client.origin = `${config.client.protocol}://${config.client.host}`;
+    config.storePath = path.resolve(config.storePath);
 
     // Configure logging.
     const loggerConfig = require('./log4js');
@@ -87,12 +88,12 @@ module.exports = (function () {
     exitHook(cb => {
         // Delay logger shutdown to capture log output when we stop other things.
         setTimeout(() => {
-            log4js.getLogger(path.parse(argv.script).name).info('Logger is stopped');
+            const loggerName = argv.script ? path.parse(argv.script).name : path.parse(argv.$0).name;
+
+            log4js.getLogger(loggerName).info('Logger is stopped');
             log4js.shutdown(cb);
         }, 3000);
     });
-
-    config.storePath = path.resolve(config.storePath);
 
     return config;
 }());

--- a/controllers/migration.js
+++ b/controllers/migration.js
@@ -1,0 +1,34 @@
+import log4js from 'log4js';
+import migrate from 'migrate-mongo';
+import migrateConfig from '../config/migrate-mongo';
+
+const logger = log4js.getLogger('migrate-mongo');
+
+/**
+ * List migrations that have not been applied (pending).
+ *
+ * @returns {string[]}
+ */
+async function listPendingMigrations() {
+    migrate.config.set(migrateConfig);
+
+    const { db, client } = await migrate.database.connect();
+    const migrationStatus = await migrate.status(db);
+
+    await client.close();
+
+    return migrationStatus.filter(item => item.appliedAt === 'PENDING').map(item => item.fileName);
+}
+
+/**
+ * Log pending migrations number at warn level.
+ */
+export function logPendingMigrations() {
+    listPendingMigrations().then(items => {
+        if (items.length) {
+            logger.warn(`${items.length} pending database migrations (${items.join(', ')})`);
+        } else {
+            logger.info('No pending database migrations');
+        }
+    });
+}

--- a/migrations/20210524112904-replace_2d_with_2dsphere.js
+++ b/migrations/20210524112904-replace_2d_with_2dsphere.js
@@ -1,0 +1,73 @@
+/**
+ * Replace 2d index with 2dsphere for support of geospacial queries on a
+ * sphere.
+ */
+module.exports = {
+    async up(db/*, client*/) {
+        // clusters
+        await db.collection('clusters').createIndex({ g: '2dsphere', z: 1 });
+        await db.collection('clusters').dropIndex({ g: '2d', z: 1 });
+
+        // clusterspaint
+        await db.collection('clusterspaint').createIndex({ g: '2dsphere', z: 1 });
+        await db.collection('clusterspaint').dropIndex({ g: '2d', z: 1 });
+
+        // photos
+        await db.collection('photos').createIndex({ geo: '2dsphere' });
+        await db.collection('photos').dropIndex({ geo: '2d' });
+
+        await db.collection('photos').createIndex({ geo: '2dsphere', year: 1 });
+        await db.collection('photos').dropIndex({ geo: '2d', year: 1 });
+
+        // photos_map
+        await db.collection('photos_map').createIndex({ geo: '2dsphere' });
+        await db.collection('photos_map').dropIndex({ geo: '2d' });
+
+        // paintings_map
+        await db.collection('paintings_map').createIndex({ geo: '2dsphere' });
+        await db.collection('paintings_map').dropIndex({ geo: '2d' });
+
+        // regions
+        await db.collection('regions').createIndex({ center: '2dsphere' });
+        await db.collection('regions').dropIndex({ center: '2d' });
+
+        // comments
+        await db.collection('comments').createIndex({ geo: '2dsphere' });
+        await db.collection('comments').dropIndex({ geo: '2d' });
+    },
+
+    async down(db/*, client*/) {
+        // Not really required, but just in case.
+
+        // clusters
+        await db.collection('clusters').createIndex({ g: '2d', z: 1 });
+        await db.collection('clusters').dropIndex({ g: '2dsphere', z: 1 });
+
+        // clusterspaint
+        await db.collection('clusterspaint').createIndex({ g: '2d', z: 1 });
+        await db.collection('clusterspaint').dropIndex({ g: '2dsphere', z: 1 });
+
+        // photos
+        await db.collection('photos').createIndex({ geo: '2d' });
+        await db.collection('photos').dropIndex({ geo: '2dsphere' });
+
+        await db.collection('photos').createIndex({ geo: '2d', year: 1 });
+        await db.collection('photos').dropIndex({ geo: '2dsphere', year: 1 });
+
+        // photos_map
+        await db.collection('photos_map').createIndex({ geo: '2d' });
+        await db.collection('photos_map').dropIndex({ geo: '2dsphere' });
+
+        // paintings_map
+        await db.collection('paintings_map').createIndex({ geo: '2d' });
+        await db.collection('paintings_map').dropIndex({ geo: '2dsphere' });
+
+        // regions
+        await db.collection('regions').createIndex({ center: '2d' });
+        await db.collection('regions').dropIndex({ center: '2dsphere' });
+
+        // comments
+        await db.collection('comments').createIndex({ geo: '2d' });
+        await db.collection('comments').dropIndex({ geo: '2dsphere' });
+    },
+};

--- a/models/Cluster.js
+++ b/models/Cluster.js
@@ -41,8 +41,8 @@ const ClusterPaintSchema = new Schema(
     { strict: true, collection: 'clusterspaint' }
 );
 
-ClusterSchema.index({ g: '2d', z: 1 });
-ClusterPaintSchema.index({ g: '2d', z: 1 });
+ClusterSchema.index({ g: '2dsphere', z: 1 });
+ClusterPaintSchema.index({ g: '2dsphere', z: 1 });
 
 const ClusterParamsSchema = new Schema(
     {

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -45,7 +45,7 @@ const CommentPSchema = new Schema(
         level: { type: Number },
         frag: { type: Boolean },
 
-        geo: { type: [Number], index: '2d' }, // Координаты [lng, lat] фотографии, которой принадлежит комментарий
+        geo: { type: [Number], index: '2dsphere' }, // Координаты [lng, lat] фотографии, которой принадлежит комментарий
 
         type: { type: Number, 'default': constants.photo.type.PHOTO, index: true }, // 1 - Photo, 2 - Painting
         // Photo's status (listed in constants)

--- a/models/Photo.js
+++ b/models/Photo.js
@@ -45,9 +45,10 @@ const PhotoSchema = new Schema({
     ucdate: { type: Date },
 
     // Coordinates, [lng, lat]
-    geo: { type: [Number], index: '2d' },
+    geo: { type: [Number], index: '2dsphere' },
 
     // Randomize selection if needed (gallery flip coin mode)
+    // We use 2d index here as random coordinates may not be valid lng/lat values.
     r2d: { type: [Number], index: '2d' },
 
     // Нельзя сделать array вхождений в регионы, так как индекс по массивам не эффективен
@@ -115,7 +116,7 @@ const PhotoSchema = new Schema({
 
 // In the main collection if photo do indexing to select on the map by year
 // Compound index http://docs.mongodb.org/manual/core/geospatial-indexes/#compound-geospatial-indexes
-PhotoSchema.index({ geo: '2d', year: 1 });
+PhotoSchema.index({ geo: '2dsphere', year: 1 });
 PhotoSchema.index({ r2d: '2d', s: 1 });
 PhotoSchema.index({ r0: 1, sdate: 1 });
 PhotoSchema.index({ r1: 1, sdate: 1 });
@@ -145,7 +146,7 @@ const PhotoHistSchema = new Schema(
 const PhotoMapSchema = new Schema(
     {
         cid: { type: Number, index: { unique: true } },
-        geo: { type: [Number], index: '2d' },
+        geo: { type: [Number], index: '2dsphere' },
         file: { type: String, required: true },
         dir: { type: String },
         title: { type: String, 'default': '' },
@@ -157,7 +158,7 @@ const PhotoMapSchema = new Schema(
 const PaintingMapSchema = new Schema(
     {
         cid: { type: Number, index: { unique: true } },
-        geo: { type: [Number], index: '2d' },
+        geo: { type: [Number], index: '2dsphere' },
         file: { type: String, required: true },
         dir: { type: String },
         title: { type: String, 'default': '' },

--- a/models/Region.js
+++ b/models/Region.js
@@ -39,7 +39,7 @@ registerModel(db => {
 
             pointsnum: { type: Number, index: true }, // Number of points
             polynum: { type: Schema.Types.Mixed, 'default': {} }, // Number of polygons {exterior: N, interior: N}
-            center: { type: [Number], index: '2d' }, // Coordinates of region's center
+            center: { type: [Number], index: '2dsphere' }, // Coordinates of region's center
             // Does region's center compute automatically(true) or setted manually(false)
             centerAuto: { type: Boolean, 'default': true, required: true },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "log4js": "6.3.0",
                 "lru-cache": "5.1.1",
                 "make-dir": "3.0.0",
+                "migrate-mongo": "8.2.2",
                 "mime": "2.4.4",
                 "moment": "2.24.0",
                 "mongoose": "5.12.2",
@@ -4139,6 +4140,14 @@
             "dev": true,
             "optional": true
         },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/aws-sdk": {
             "version": "2.610.0",
             "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.610.0.tgz",
@@ -4673,6 +4682,22 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
+        "node_modules/cli-table3": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+            "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+            "dependencies": {
+                "colors": "^1.1.2",
+                "object-assign": "^4.1.0",
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": "10.* || >= 12.*"
+            },
+            "optionalDependencies": {
+                "colors": "^1.1.2"
+            }
+        },
         "node_modules/cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -4866,7 +4891,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.1.90"
             }
@@ -6472,6 +6497,14 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
             "dev": true
+        },
+        "node_modules/fn-args": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+            "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw==",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/follow-redirects": {
             "version": "1.13.0",
@@ -9396,6 +9429,81 @@
                 "node": ">=8"
             }
         },
+        "node_modules/migrate-mongo": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-8.2.2.tgz",
+            "integrity": "sha512-RK8zE9QGzaDZ8xN+Cyb/mUhSIA1pkj1Q/aNYeH4QB9U2UNfKej1lmxh20Ot1xFl1C62ro3hqiaZ9QErzCN3qPw==",
+            "dependencies": {
+                "cli-table3": "^0.6.0",
+                "commander": "^7.1.0",
+                "date-fns": "^2.19.0",
+                "fn-args": "^5.0.0",
+                "fs-extra": "^9.1.0",
+                "lodash": "^4.17.21",
+                "mongodb": "^3.6.4",
+                "p-each-series": "^2.2.0"
+            },
+            "bin": {
+                "migrate-mongo": "bin/migrate-mongo.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/migrate-mongo/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/migrate-mongo/node_modules/date-fns": {
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+            "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
+        },
+        "node_modules/migrate-mongo/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/migrate-mongo/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/migrate-mongo/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/mime": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
@@ -10197,6 +10305,17 @@
             "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/p-each-series": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-finally": {
@@ -16639,6 +16758,11 @@
             "dev": true,
             "optional": true
         },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+        },
         "aws-sdk": {
             "version": "2.610.0",
             "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.610.0.tgz",
@@ -17055,6 +17179,16 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
+        "cli-table3": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+            "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+            "requires": {
+                "colors": "^1.1.2",
+                "object-assign": "^4.1.0",
+                "string-width": "^4.2.0"
+            }
+        },
         "cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -17209,7 +17343,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-            "dev": true
+            "devOptional": true
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -18507,6 +18641,11 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
             "dev": true
+        },
+        "fn-args": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+            "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw=="
         },
         "follow-redirects": {
             "version": "1.13.0",
@@ -20693,6 +20832,58 @@
                 "picomatch": "^2.0.5"
             }
         },
+        "migrate-mongo": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-8.2.2.tgz",
+            "integrity": "sha512-RK8zE9QGzaDZ8xN+Cyb/mUhSIA1pkj1Q/aNYeH4QB9U2UNfKej1lmxh20Ot1xFl1C62ro3hqiaZ9QErzCN3qPw==",
+            "requires": {
+                "cli-table3": "^0.6.0",
+                "commander": "^7.1.0",
+                "date-fns": "^2.19.0",
+                "fn-args": "^5.0.0",
+                "fs-extra": "^9.1.0",
+                "lodash": "^4.17.21",
+                "mongodb": "^3.6.4",
+                "p-each-series": "^2.2.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+                },
+                "date-fns": {
+                    "version": "2.21.3",
+                    "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+                    "integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw=="
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+                }
+            }
+        },
         "mime": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
@@ -21287,6 +21478,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
             "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ=="
+        },
+        "p-each-series": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA=="
         },
         "p-finally": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,12 @@
         "lint": "./node_modules/.bin/eslint .",
         "lintfix": "./node_modules/.bin/eslint . --fix",
         "build": "grunt",
-        "test": "grunt test"
+        "test": "grunt test",
+        "migrate": "npm run migrate:up",
+        "migrate:create": "migrate-mongo create -f config/migrate-mongo.js -- ",
+        "migrate:status": "migrate-mongo status -f config/migrate-mongo.js",
+        "migrate:up": "migrate-mongo up -f config/migrate-mongo.js",
+        "migrate:down": "migrate-mongo down -f config/migrate-mongo.js"
     },
     "dependencies": {
         "@mapbox/geojson-area": "0.2.2",
@@ -67,6 +72,7 @@
         "log4js": "6.3.0",
         "lru-cache": "5.1.1",
         "make-dir": "3.0.0",
+        "migrate-mongo": "8.2.2",
         "mime": "2.4.4",
         "moment": "2.24.0",
         "mongoose": "5.12.2",


### PR DESCRIPTION
This is a final part 7 of Mongo 4 migration task (#191). This patchset is including database migration tool integration and migration to `2dsphere` index.

### What is included
* Add migrate-mongo 8.2.2 - this adds [migrate-mongo](https://github.com/seppevs/migrate-mongo) tool for managing database upgrades.
* Add migration to replace `2d` index with `2dsphere` - this is needed to support of wider range of geospatial queries which we may start using for upcoming features.
   * Index was not changed to 2dsphere for `r2d` field in Photo collection, it contains random coordinates that may not be valid lng/lat values.

**migrate-mongo**
To be able to use non-default config file location, and for general convenience (i.e. to automatically start Mongo container when run though docker), the following scripts were added to `package.json`:

`migrate:create` - alias for `migrate-mongo create`
`migrate:status` - alias for `migrate-mongo status`
`migrate:up` - alias for `migrate-mongo up`
`migrate:down` - alias for `migrate-mongo down`
`migrate` - alias for `migrate:up` script

To execute, user is supposed to run:
```
docker-compose run app npm run migrate:up
```

Currently, when app node instance is started, pending migration status is reported to log (with warn level if there are pending migrations).

Automatic migration (e.g. on app start) is not implemented yet. If we need it, I am not sure how this should work. Possible options (please suggest more):
* "migrate up" should be done on worker instance when it is started
  * In this case should other node instances "wait" till migration is completed on worker or load as normal?
* Trigger migration from admin UI (e.g. show pending migration status and button to run migration).

