### PR TITLE
docker-compose: Use default tag to avoid image per instance.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 x-defaults: &app-image
   build: .
+  image: pastvu_node
 
 services:
   mongo:


### PR DESCRIPTION
This simple fix adds a default buld image name, so that all compose instances use the same once first app instance built one (instead of building own per instance).

Basically turns this:
![image](https://user-images.githubusercontent.com/329780/137026379-015450ad-d417-403d-a11c-83fe716d3903.png)

into this:

![image](https://user-images.githubusercontent.com/329780/137026492-bd7b9763-6430-42c5-9c48-5b01d729919b.png)


