### PR TITLE
MongoDB 4.x migration - Fix clusters

### DIFF
--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -721,12 +721,25 @@ Utils.geo = (function () {
         return geo;
     }
 
-    function spinLng(geo) {
+    /**
+     * Normalize coordinates.
+     *
+     * This spins longtitude if required and makes sure latitude is not out of
+     * EPSG:4326 permitted range.
+     *
+     * @param {Array} geo coordiante pair [lng, lat]
+     */
+    function normalizeCoordinates(geo) {
+        // Spin longtitude.
         if (geo[0] < -180) {
             geo[0] += 360;
         } else if (geo[0] > 180) {
             geo[0] -= 360;
         }
+
+        // Limit latitude.
+        geo[1] = Math.min(geo[1], 89.999999);
+        geo[1] = Math.max(geo[1], -89.999999);
     }
 
     function latlngToArr(ll, lngFirst) {
@@ -806,7 +819,7 @@ Utils.geo = (function () {
         polyBBOX,
         polyArea,
         sortPolygonSegmentsByArea,
-        spinLng,
+        normalizeCoordinates,
         latlngToArr,
         check,
         checkLatLng,

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -180,13 +180,8 @@ export const clusterPhotosAll = async function (params) {
                         cluster.geo[1] = Math.round(divider * (cluster.geo[1] / (cluster.c + 1))) / divider;
                     }
 
-                    if (cluster.geo[0] < -180 || cluster.geo[0] > 180) {
-                        Utils.geo.spinLng(cluster.geo);
-                    }
-
-                    if (cluster.g[0] < -180 || cluster.g[0] > 180) {
-                        Utils.geo.spinLng(cluster.g);
-                    }
+                    Utils.geo.normalizeCoordinates(cluster.geo);
+                    Utils.geo.normalizeCoordinates(cluster.g);
 
                     // Link it to photo that will represent cluster.
                     cluster.p = await Photo.findOne({
@@ -226,9 +221,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
     const ClusterModel = isPainting ? ClusterPaint : Cluster;
     const $update = { $set: {} };
 
-    if (g[0] < -180 || g[0] > 180) {
-        Utils.geo.spinLng(g);
-    }
+    Utils.geo.normalizeCoordinates(g);
 
     const cluster = await ClusterModel.findOne(
         { g, z: zParam.z }, { _id: 0, c: 1, geo: 1, y: 1, p: 1 }, { lean: true }
@@ -241,10 +234,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
 
     if (!geoCluster) {
         geoCluster = [g[0] + zParam.wHalf, g[1] - zParam.hHalf];
-
-        if (geoCluster[0] < -180 || geoCluster[0] > 180) {
-            Utils.geo.spinLng(geoCluster);
-        }
+        Utils.geo.normalizeCoordinates(geoCluster);
     }
 
     if (geoPhotos.o) {
@@ -304,9 +294,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
             ]);
         }
 
-        if (geoCluster[0] < -180 || geoCluster[0] > 180) {
-            Utils.geo.spinLng(geoCluster);
-        }
+        Utils.geo.normalizeCoordinates(geoCluster);
     }
 
     const photo = await Photo.findOne(
@@ -545,7 +533,6 @@ recalcAll.isPublic = true;
 
 export default {
     recalcAll,
-
     clusterPhoto,
     declusterPhoto,
     getBounds,

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -10,8 +10,8 @@ import { runJob } from './queue';
 
 const logger = log4js.getLogger('cluster.js');
 
-export let clusterParams; // Parameters of cluster
-export let clusterConditions; // Parameters of cluster settings
+let clusterParams; // Parameters of cluster
+let clusterConditions; // Parameters of cluster settings
 
 async function readClusterParams() {
     [clusterParams, clusterConditions] = await Promise.all([
@@ -516,10 +516,20 @@ async function getClusterPoster(cluster, yearCriteria, isPainting) {
     return cluster;
 }
 
-// After connection to db read current cluster parameters
+/**
+ * Return cluster conditions for client use.
+ *
+ * @returns {object} object containing result.
+ */
+function getClusterConditions() {
+    return clusterConditions;
+}
+
+// After connection to db read current cluster parameters.
 waitDb.then(readClusterParams);
 
 recalcAll.isPublic = true;
+getClusterConditions.isPublic = true;
 
 export default {
     recalcAll,
@@ -527,4 +537,5 @@ export default {
     declusterPhoto,
     getBounds,
     getBoundsByYear,
+    getClusterConditions,
 };

--- a/migrations/20210524112904-replace_2d_with_2dsphere.js
+++ b/migrations/20210524112904-replace_2d_with_2dsphere.js
@@ -7,6 +7,11 @@ module.exports = {
         // Use transaction.
         const session = client.startSession();
 
+        // Fix clusters that have out of range latitude. There are few edge
+        // cases that belong to north pole photos.
+        await db.collection('clusters').updateMany({ 'g.1': { $gt: 89.999999 } }, { $set: { 'g.1': 89.999999 } });
+        await db.collection('clusters').updateMany({ 'geo.1': { $gt: 89.999999 } }, { $set: { 'g.1': 89.999999 } });
+
         try {
             await session.withTransaction(async () => {
                 // clusters

--- a/public/js/module/map/mapClusterCalc.js
+++ b/public/js/module/map/mapClusterCalc.js
@@ -14,6 +14,10 @@ define([
         options: {
             deferredWhenReady: null // Deffered wich will be resolved when map ready
         },
+        defaults: {
+            w: 40,
+            h: 40,
+        },
         create: function () {
             this.destroy = _.wrap(this.destroy, this.localDestroy);
             this.auth = globalVM.repository['m/common/auth'];
@@ -27,12 +31,15 @@ define([
 
             this.exe = ko.observable(false); //Указывает, что сейчас идет обработка запроса на действие к серверу
             this.exePercent = ko.observable(0); //Указывает, что сейчас идет обработка запроса на действие к серверу
-            this.wCurr = ko.observable(40);
-            this.wNew = ko.observable(40);
-            this.hCurr = ko.observable(40);
-            this.hNew = ko.observable(40);
+            this.wCurr = ko.observable(this.defaults.w);
+            this.wNew = ko.observable(this.defaults.w);
+            this.hCurr = ko.observable(this.defaults.h);
+            this.hNew = ko.observable(this.defaults.h);
             this.changed = this.co.changed = ko.computed(function () {
                 return this.wCurr() !== this.wNew() || this.hCurr() !== this.hNew();
+            }, this);
+            this.isDefault = ko.computed(function () {
+                return this.wCurr() === this.defaults.w || this.hCurr() === this.defaults.h;
             }, this);
 
             if (P.settings.USE_OSM_API()) {
@@ -139,6 +146,15 @@ define([
 
             ko.applyBindings(globalVM, this.$dom[0]);
 
+            socket.run('cluster.getClusterConditions').then(function (data) {
+                if (data) {
+                    this.wCurr(data.sw);
+                    this.hCurr(data.sh);
+                    this.wNew(data.sw);
+                    this.hNew(data.sh);
+                }
+            }.bind(this));
+
             this.show();
         },
         show: function () {
@@ -194,7 +210,10 @@ define([
             this.map = null;
             destroy.call(this);
         },
-
+        setDefaults: function () {
+            this.wNew(this.defaults.w);
+            this.hNew(this.defaults.h);
+        },
         save: function () {
             var _this = this;
 

--- a/views/module/map/mapClusterCalc.pug
+++ b/views/module/map/mapClusterCalc.pug
@@ -29,6 +29,8 @@
         button.btn.btn-warning.btnSave(type="button", data-bind="click: cancel")
             span.glyphicon.glyphicon-exclamation-sign
             |  Cancel
+    button.btn.btn-primary.btnSave(type="button", data-bind="style: {display: changed() || isDefault() ? 'none' : ''}, click: setDefaults")
+        | Reset to default
     p(style="margin-top: 6px; margin-bottom: 0;", data-bind="style: {display: exe() && changed() ? '' : 'none'}") Процесс расчета новых параметров на разных уровнях зума:
     .progress.progress-striped.active(data-bind="style: {display: exe() && changed() ? '' : 'none'}")
         .progress-bar.progress-bar-success(data-bind="style: {width: exePercent() + '%'}")


### PR DESCRIPTION
The attmpt to run `2dsphere` migration routine on staging resulted in error: `can't project geometry into spherical CSR`.
![image](https://user-images.githubusercontent.com/329780/139557770-3477f07a-ec3d-48e2-a7f5-c0ff7451af8e.png)

This is caused by violation of EPSG:4326 permitted range of coordinates in some cluster records identifiable using queries:
```
db.clusters.find({g: {$not: {$geoWithin : { $box : [ [ -180 , -90 ] , [ 180 , 90 ] ] }}}})
db.clusters.find({geo: {$not: {$geoWithin : { $box : [ [ -180 , -90 ] , [ 180 , 90 ] ] }}}})
```
that return cluster collection records related to two photos located close to north pole (https://pastvu.com/p/496298 and https://pastvu.com/p/466101)

This patch address the issues in a way:

1. Change in migration routine to find cluster records with out of range coordniated and set latitude to those to 89.999999.
2. Change in cluster controller to normalise computed coordinates, so that latitude never becomes out of EPSG:4326 permitted range (limit them to -89.999999/89.999999) in future.
3. Fix querying objects close to north and south poles in UI (#396) by expanding query boundaries (north and south latitudes) when top/bottom edge of map is shown on the screen.
4. Makes cluster calculation interface show actual current cluster size and possibility to reset it to default size if it is different to defaults:
![image](https://user-images.githubusercontent.com/329780/139558275-9d5c35fd-f209-4bba-bafb-bd2910636259.png)
    once clicked, the interfaces changes to normal conversion interface (as if user changed size of cluster manually):

    ![image](https://user-images.githubusercontent.com/329780/139558314-cd890784-16b8-41bc-8b50-cd118bef43bc.png)
When current size is matching default, button is not shown. It is also not shown when changes to cluster size is made, but not saved.

As sanity check, the Mongo DB query was built to check all fields containing geo data in all collections for possible EPSG:4326 range violations that may affect `2dsphere` index creation. This did not return anything different to known records in `clusters` collection. Just in case it may come useful one day:
```
db.adminCommand("listDatabases").databases.forEach(function(d){
  let mdb = db.getSiblingDB(d.name);
  mdb.getCollectionInfos({ type: "collection" }).forEach(function(c){
     let currentCollection = mdb.getCollection(c.name);
     currentCollection.getIndexes().forEach(function(idx){
       let idxValues = Object.values(Object.assign({}, idx.key));
       if (idxValues.includes("2d")) {
         if (idx.key.hasOwnProperty("g")) {
           condition = {$exists: true, $not: {$geoWithin: { $box: [ [ -180 , -90 ] , [ 180 , 90 ] ] }}};
           cursor = db[c.name].find({$or: [{g: condition}, {geo: condition}, {center: condition}]});
           while ( cursor.hasNext() ) {
             doc = cursor.next();
             print("Out of range property: " + doc._id + " on " + c.name);
             //printjson( doc );
           }
         }
       }
     });
  });
});
```

