### PR TITLE
MongoDB 4.x migration - Fix 2dsphere index migration

### DIFF
--- a/migrations/20210524112904-replace_2d_with_2dsphere.js
+++ b/migrations/20210524112904-replace_2d_with_2dsphere.js
@@ -3,92 +3,49 @@
  * sphere.
  */
 module.exports = {
-    async up(db, client) {
-        // Use transaction.
-        const session = client.startSession();
-
+    async up(db/*, client*/) {
         // Fix clusters that have out of range latitude. There are few edge
         // cases that belong to north pole photos.
         await db.collection('clusters').updateMany({ 'g.1': { $gt: 89.999999 } }, { $set: { 'g.1': 89.999999 } });
-        await db.collection('clusters').updateMany({ 'geo.1': { $gt: 89.999999 } }, { $set: { 'g.1': 89.999999 } });
+        await db.collection('clusters').updateMany({ 'geo.1': { $gt: 89.999999 } }, { $set: { 'geo.1': 89.999999 } });
 
-        try {
-            await session.withTransaction(async () => {
-                // clusters
-                await db.collection('clusters').createIndex({ g: '2dsphere', z: 1 });
-                await db.collection('clusters').dropIndex({ g: '2d', z: 1 });
-
-                // clusterspaint
-                await db.collection('clusterspaint').createIndex({ g: '2dsphere', z: 1 });
-                await db.collection('clusterspaint').dropIndex({ g: '2d', z: 1 });
-
-                // photos
-                await db.collection('photos').createIndex({ geo: '2dsphere' });
-                await db.collection('photos').dropIndex({ geo: '2d' });
-
-                await db.collection('photos').createIndex({ geo: '2dsphere', year: 1 });
-                await db.collection('photos').dropIndex({ geo: '2d', year: 1 });
-
-                // photos_map
-                await db.collection('photos_map').createIndex({ geo: '2dsphere' });
-                await db.collection('photos_map').dropIndex({ geo: '2d' });
-
-                // paintings_map
-                await db.collection('paintings_map').createIndex({ geo: '2dsphere' });
-                await db.collection('paintings_map').dropIndex({ geo: '2d' });
-
-                // regions
-                await db.collection('regions').createIndex({ center: '2dsphere' });
-                await db.collection('regions').dropIndex({ center: '2d' });
-
-                // comments
-                await db.collection('comments').createIndex({ geo: '2dsphere' });
-                await db.collection('comments').dropIndex({ geo: '2d' });
-            });
-        } finally {
-            await session.endSession();
-        }
+        // Creation of 2dsphere indexes according to model defintion and
+        // deletion of redundant ones will be performed by syncAllIndexes call
+        // on worker.
     },
 
-    async down(db, client) {
-        // Not really required, but just in case.
-        const session = client.startSession();
+    async down(db/*, client*/) {
+        // Not really required, but if we go to the code state before 2dsphere
+        // migration, syncAllIndexes won't be available at that point,
+        // so revert all index changes.
+        await db.collection('clusters').createIndex({ g: '2d', z: 1 });
+        await db.collection('clusters').dropIndex({ g: '2dsphere', z: 1 });
 
-        try {
-            await session.withTransaction(async () => {
-                // clusters
-                await db.collection('clusters').createIndex({ g: '2d', z: 1 });
-                await db.collection('clusters').dropIndex({ g: '2dsphere', z: 1 });
+        // clusterspaint
+        await db.collection('clusterspaint').createIndex({ g: '2d', z: 1 });
+        await db.collection('clusterspaint').dropIndex({ g: '2dsphere', z: 1 });
 
-                // clusterspaint
-                await db.collection('clusterspaint').createIndex({ g: '2d', z: 1 });
-                await db.collection('clusterspaint').dropIndex({ g: '2dsphere', z: 1 });
+        // photos
+        await db.collection('photos').createIndex({ geo: '2d' });
+        await db.collection('photos').dropIndex({ geo: '2dsphere' });
 
-                // photos
-                await db.collection('photos').createIndex({ geo: '2d' });
-                await db.collection('photos').dropIndex({ geo: '2dsphere' });
+        await db.collection('photos').createIndex({ geo: '2d', year: 1 });
+        await db.collection('photos').dropIndex({ geo: '2dsphere', year: 1 });
 
-                await db.collection('photos').createIndex({ geo: '2d', year: 1 });
-                await db.collection('photos').dropIndex({ geo: '2dsphere', year: 1 });
+        // photos_map
+        await db.collection('photos_map').createIndex({ geo: '2d' });
+        await db.collection('photos_map').dropIndex({ geo: '2dsphere' });
 
-                // photos_map
-                await db.collection('photos_map').createIndex({ geo: '2d' });
-                await db.collection('photos_map').dropIndex({ geo: '2dsphere' });
+        // paintings_map
+        await db.collection('paintings_map').createIndex({ geo: '2d' });
+        await db.collection('paintings_map').dropIndex({ geo: '2dsphere' });
 
-                // paintings_map
-                await db.collection('paintings_map').createIndex({ geo: '2d' });
-                await db.collection('paintings_map').dropIndex({ geo: '2dsphere' });
+        // regions
+        await db.collection('regions').createIndex({ center: '2d' });
+        await db.collection('regions').dropIndex({ center: '2dsphere' });
 
-                // regions
-                await db.collection('regions').createIndex({ center: '2d' });
-                await db.collection('regions').dropIndex({ center: '2dsphere' });
-
-                // comments
-                await db.collection('comments').createIndex({ geo: '2d' });
-                await db.collection('comments').dropIndex({ geo: '2dsphere' });
-            });
-        } finally {
-            await session.endSession();
-        }
+        // comments
+        await db.collection('comments').createIndex({ geo: '2d' });
+        await db.collection('comments').dropIndex({ geo: '2dsphere' });
     },
 };

--- a/worker.js
+++ b/worker.js
@@ -2,7 +2,7 @@ import ms from 'ms';
 import moment from 'moment';
 import log4js from 'log4js';
 import config from './config';
-import connectDb, { waitDb } from './controllers/connection';
+import connectDb, { waitDb, syncAllIndexes } from './controllers/connection';
 import { checkPendingMigrations } from './controllers/migration';
 import { archiveExpiredSessions, calcUserStats } from './controllers/_session';
 import { convertPhotosAll } from './controllers/converter';
@@ -31,6 +31,10 @@ export async function configure(startStamp) {
     logger.info(`Worker started up in ${(Date.now() - startStamp) / 1000}s`);
 
     waitDb.then(() => {
+        logger.info('Syncing indexes defined in model schemas to MongoDB.');
+
+        return syncAllIndexes();
+    }).then(() => {
         setupSessionQueue();
         setupUserJobsQueue();
     });


### PR DESCRIPTION
It looks like creation of collection indexes may conflict with `autoIndex` feature in Mongoose (enabled by default) in a way that attempt to create index using explicit `createIndex` call result in error (`a background operation is currently running for collection...`). Intermediate solution was not to call `createIndex` in migration routine, only drop `2d` and let `autoIndex` to create `2dsphere` according to Models, but it seems there is a better option to disable `autoIndex` and trigger [`Model.syncIndexes`](https://mongoosejs.com/docs/api.html#model_Model.syncIndexes) on the worker instance for better control and consistency. This way we can ensure that collection indexes are always in line with Model definition and sync is run on the separate instance to ensure there is no race condition with other instances that potentially may happen if `autoIndex` is used. For more info on `syncIndexes`, refer to [this page](https://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes). `syncIndexes` is non-locking operation, so db can be used as normal by other clients, but performance may be affected while it is running.

For info, `2dsphere` indexes build on staging takes just a few minutes (checked using `db.currentOp()`), so it should not slow down Mongo 4 migration process.

 