### PR TITLE
Changes to db initialisation in dev environment.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
                 command: () => {
                     const error = 'Version defined in Dockerfile is not matching package version of node.';
                     const pkgVersion = grunt.template.process('<%= pkg.engines.node %>');
-                    const dockerParse = "sed -n -e '/^ARG NODE_TAG/ s/.*=//p' Dockerfile";
+                    const dockerParse = "sed -n -e '/^ARG NODE_TAG/ s/.*=//p' ./docker/Dockerfile";
 
                     return 'if [ "$(' + dockerParse + ')" != "' + pkgVersion + '" ]; then echo "' + error + '"; exit 1; fi;';
                 },

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ We welcome any keen developer in helping us build the better PastVu. You can ins
 You need to have [docker](https://docs.docker.com/engine/install/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
 
 ```bash
+# Start Mongo container in background
+docker-compose up -d mongo
+# Import Pastvu database
+docker-compose exec mongo initdb
 # Install node modules
 docker-compose run app npm install
 # Start the application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 x-defaults: &app-image
-  build: .
+  build: ./docker
   image: pastvu_node
   environment:
     - NODE_ENV=development
@@ -11,6 +11,7 @@ services:
     image: mongo:4.4
     volumes:
       - mongo:/data/db
+      - ./docker/dev-initdb.sh:/usr/local/bin/initdb
     expose:
       - "27017"
     ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,9 @@ FROM node:$NODE_TAG
 RUN apt-get update && apt-get install -y \
     graphicsmagick \
     webp \
-    wait-for-it \
 && rm -rf /var/lib/apt/lists/*
-COPY ./docker/imagick-policy.xml /etc/ImageMagick-6/policy.xml
+COPY ./imagick-policy.xml /etc/ImageMagick-6/policy.xml
 WORKDIR /code
 
-COPY ./docker/dev-entrypoint.sh /usr/local/bin/
+COPY ./dev-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["dev-entrypoint.sh"]

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -8,7 +8,6 @@ CONFIG="./config/local.config.js"
 # 'run MODULE [options]' special command to run script directly with node, so that system signals are relayed to the process.
 if [ "$1" = 'run' -a -f "./${2}.js" ]; then
   MODULE=$2
-  wait-for-it -t 0 mongo:27017
   shift 2
   exec node ./bin/run.js --script "./${MODULE}.js" "$@"
 fi

--- a/docker/dev-initdb.sh
+++ b/docker/dev-initdb.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
-curl -s -o /tmp/pastvu.gz https://varlamov.me/pastvu/github/pastvu.gz
-mongorestore --gzip --db pastvu --archive=/tmp/pastvu.gz
+
+# This test database restore script is designed to be bind mounted inside mongo
+# container at /usr/local/bin/initdb location, then called on started container as
+# 'docker-compose exec mongo initdb'.
+if ! command -v curl; then
+    echo "Installing curl"
+    apt update -qq  && apt-get install -yqq curl
+fi
+echo "Downloading db dump..."
+curl --progress-bar -o /tmp/pastvu.gz https://varlamov.me/pastvu/github/pastvu.gz
+mongorestore --drop --gzip --db pastvu --archive=/tmp/pastvu.gz
 rm /tmp/pastvu.gz

--- a/docker/dev-mongo.Dockerfile
+++ b/docker/dev-mongo.Dockerfile
@@ -1,3 +1,0 @@
-FROM pastvu/mongo:3.2.22
-RUN apt-get update && apt-get install -y curl
-COPY ./dev-initdb.sh /docker-entrypoint-initdb.d/initdb.sh


### PR DESCRIPTION
This simplifies dev environment db initialisation. In particular, it re-implements database initialisation without using Mongo image wrapper Dockerfile.

To sum up:
* Move node Dockerfile to docker directory
* Remove Mongo image wrapper Dockerfile
* Bind mount dev-initdb.sh in the Mongo container
* README changes to reflect above.

Note on `wait-for-it` use, it only works if timing is right and app container starts exactly at point when db restore (not the downloading of dump) is ongoing. E.g. if at the point of running `docker-compose up`, dump downloading is still ongoing, developer will see the error on attempt to start the app:
![image](https://user-images.githubusercontent.com/329780/140620121-cf477e14-c350-461e-a6e6-79dfc1b3cf2f.png)

Without knowing context (that dump download/restore is run on background of mongo container startup), this might be difficult for unexperienced person to understand the reason, I think controlled process of db initialisation, when a separate command needs to be executed as part of dev environment setup, is more intuitive.