### PR TITLE
Check if database exists at connection and mongo4 volume name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   mongo:
     image: mongo:4.4
     volumes:
-      - mongo:/data/db
+      - mongo4:/data/db
       - ./docker/dev-initdb.sh:/usr/local/bin/initdb
     expose:
       - "27017"
@@ -96,4 +96,4 @@ services:
 volumes:
   store:
   sitemap:
-  mongo:
+  mongo4:


### PR DESCRIPTION
* Check if database exists at connection - since it is compulsory for app (MongoDB allows using non-existing database at the point of connection, this is not an error). Also minor refactoring of connection function.
* Rename DB volume to `mongo4` - Mongodb 4 can't start on previous version volume (without re-creating it and restore), I suggest to use a different name. This approach will also simplify development for next mongo release (no need to maintain changes in docker-compose.yml when switching between master and feature branch).