### PR TITLE
MongoDB 4.x migration: bugfixes

### DIFF
--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -368,9 +368,8 @@ async function updateSession(session, ip, headers, browser) {
     }
 
     data.headers = headers;
-    session.markModified('data');
 
-    return session.save();
+    return Session.findOneAndUpdate({ _id: session._id }, session);
 }
 
 // Create session as copy from transfered session (ip, header, agent)

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -461,20 +461,22 @@ async function archiveSession(session, reason) {
 async function popUserRegions(usObj) {
     const user = usObj.user;
     const registered = usObj.registered;
-    const pathPrefix = registered ? '' : 'anonym.';
     const paths = [
         {
-            path: pathPrefix + 'regionHome',
+            path: 'regionHome',
             select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1, center: 1, bbox: 1, bboxhome: 1 },
         },
-        { path: pathPrefix + 'regions', select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1 } },
+        {
+            path: 'regions',
+            select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1 },
+        },
     ];
 
     let modregionsEquals; // Profile regions and moderation regions are equals
 
     if (registered && user.role === 5) {
         modregionsEquals = _.isEqual(user.regions, user.mod_regions) || undefined;
-        paths.push({ path: pathPrefix + 'mod_regions', select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1 } });
+        paths.push({ path: 'mod_regions', select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1 } });
     }
 
     await user.populate(paths).execPopulate();

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -1179,7 +1179,7 @@ async function destroyUserSession({ login, key: sid }) {
 
 // Destroy all user sessions, is done by admin while changing login user restriction from on to off on manage page
 async function destroyUserSessions({ login }) {
-    const sessions = await this.call('session.giveUserSessions', { login });
+    const { sessions } = await this.call('session.giveUserSessions', { login });
 
     await Promise.all(sessions.map(session => this.call('session.destroyUserSession', { login, key: session.key })));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "pastvu",
-            "version": "1.4.7",
+            "version": "2.0.0-pre1",
             "dependencies": {
                 "@mapbox/geojson-area": "0.2.2",
                 "@mapbox/geojson-rewind": "0.5.0",

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -172,11 +172,9 @@ require([
     $.when(routerDeferred.promise()).then(function () {
         router.start();
         // App info in console.
-        const style = `color: #204A6B; font-family:monospace; background: url(${location.origin}/favicon.ico) left/contain no-repeat; padding-left: 10px`;
         const string = `PastVu App v${P.settings.version()} loaded. Bug reports and contribs are welcome at https://github.com/PastVu/pastvu`;
-        console.log("%c " + string, style);
+        console.log("%c ✪ %c" + string, "color: #E07C79; font-size: 1.5em;", "color: #3585F7; font-family: monospace;");
     });
-
     // window.appRouter = globalVM.router;
     // window.glob = globalVM;
 });

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -481,7 +481,8 @@ define([
                 zoom: zoom,
                 zoomAnimation: L.Map.prototype.options.zoomAnimation && true,
                 trackResize: false,
-                zoomControl: false // Remove default zoom control (we use our own)
+                zoomControl: false, // Remove default zoom control (we use our own)
+                tap: false, // TODO: Prevent double click in Safari, remove when Leaflet/Leaflet#7255 is addressed.
             });
             if (fitBounds) {
                 this.map.fitBounds(fitBounds, { maxZoom: defaults.maxZoom });


### PR DESCRIPTION
* #411 - when app is open in many browser tabs, logout in one results in refresh of all tabs, that in turn causes `Can't save() the same doc multiple times in parallel` error in Mongoose when updating session. To prevent issue, update a new instance of document rather than use save() (see https://github.com/Automattic/mongoose/issues/8132 for more details).
* #407 - minor issue (object destructing was missing)
* #406 - interesting one, when object is Mongoose subdocument, its population (`Document.populate()`) seems require path to respect actual object keys, not schema properties (worked fine in Mongoose 4). In this particular case `user` is derived from `session.anonym`, but when population path property specifies `anonym.regions`, it seems ignored (not populated, objects is returned unchanged), then it fails when content of regions property is processed at later stage. The fix is addressing the issue. Tested both at UI and session collection record content, seems work as expected now.
* #414 - Issue in Leaflet causing double click event in Safari, workaround is to set map's tap property to false (not critical for us, we don't use long taps for context menus).

Also fixes background duplication in console log in Safari (see screenshot of the issue in #414)