### PR TITLE
remove preconnection to kosmosnimki

### DIFF
--- a/views/includes/head_meta.pug
+++ b/views/includes/head_meta.pug
@@ -60,11 +60,6 @@ link(rel="apple-touch-icon", sizes="72x72", href="/apple-touch-icon-72x72.png")
 link(rel="apple-touch-icon", sizes="60x60", href="/apple-touch-icon-60x60.png")
 link(rel="apple-touch-icon", href="/apple-touch-icon.png")
 
-//- https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/
-link(rel="preconnect", href="http://a.tile.osm.kosmosnimki.ru", crossorigin)
-link(rel="preconnect", href="http://b.tile.osm.kosmosnimki.ru", crossorigin)
-link(rel="preconnect", href="http://c.tile.osm.kosmosnimki.ru", crossorigin)
-
 //-Фоновый цвет на старт-скрине Windows 8
 meta(name="msapplication-TileColor", content="#214A7A")
 //-Иконка для старт-скрина Windows 8


### PR DESCRIPTION
Адреса `*.tile.osm.kosmosnimki.ru` уже давно не актуальны.

Есть вариант выпилить совсем `preconnection`, как предлагается в этом PR,
либо реализовать `preconnection` на `JS`, как описано [по ссылке из комментария](https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/).