### PR TITLE
Fix distance range in giveNearestPhotos

### DIFF
--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1977,11 +1977,11 @@ async function giveNearestPhotos({ geo, type, year, year2, except, distance, lim
         query.cid = { $ne: except };
     }
 
-    // For 2dsphere GeoJSON point $maxDistance is specified in meters.
-    if (_.isNumber(distance) && distance > 0 && distance < 7) {
+    if (_.isNumber(distance) && distance > 0 && distance < Math.PI) {
         query.geo.$nearSphere.$maxDistance = Utils.geo.rad2meter(distance);
     } else {
-        query.geo.$nearSphere.$maxDistance = Utils.geo.rad2meter(2);
+        // By default restrict distance to hemisphere with the center at the point.
+        query.geo.$nearSphere.$maxDistance = Utils.geo.rad2meter(Math.PI / 2);
     }
 
     if (_.isNumber(limit) && limit > 0 && limit < 30) {


### PR DESCRIPTION
Quick follow up to #431, so I won't forget.

Since we now use $nearSphere to fetch 2dsphere indexed points, the maximum possible distance to point is Pi rads. Patch also changes default distance to Pi / 2 rads (a hemisphere with center at the point that we use in search).