### PR TITLE
Automatically create GitHub release on tagging commit.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Fixed
+      labels:
+        - "Bug"
+    - title: New features
+      labels:
+        - "Feature Request"
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
   push:
     branches:
-      - '**'
+      - 'master'
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Tagged Release
+
+on:
+  push:
+    tags:
+      - '*'
+      - '!**-en'
+
+jobs:
+  release:
+    name: Tagged Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+


### PR DESCRIPTION
The release notes will be automatically populated and include list of changes between current and previous tag.

Example to demonstrate concept: https://github.com/kabalin/pastvu/releases

On repo containing PRs (this one) is supposed to contain more information (according to .github/release.yml instruction), we will test how it looks on next release 😃 

More info on topic:
* https://github.com/softprops/action-gh-release
* https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options