### PR TITLE
Terminate application if Redis connection can't be restored.

### DIFF
--- a/config/default.config.js
+++ b/config/default.config.js
@@ -78,7 +78,7 @@ module.exports = {
         host: 'localhost',
         port: '6379',
         autoResendUnfulfilledCommands: false,
-        maxReconnectTime: ms('30s'),
+        maxReconnectTime: ms('60s'),
     },
 
     // Lifetime of link to file of protected photo for user, that has right to see this photo

--- a/worker.js
+++ b/worker.js
@@ -53,7 +53,7 @@ function setupSessionQueue() {
 
         // Add archiveExpiredSessions periodic job.
         sessionQueue.add('archiveExpiredSessions', {}, {
-            removeOnComplete: 2, // Needed to be able to retrieve it on global even listener (in different runner).
+            removeOnComplete: 2, // Needed to be able to retrieve it on global event listener (in different runner).
             removeOnFail: true,
             repeat: { every: ms('5m') },
         });


### PR DESCRIPTION
Currently if Redis become unavailable during run, we reattempt to connect for config.redis.maxReconnectTime, if no success we leave a stale process running that is not operational any more. Instead, terminate process, so that orchestration system notice it and attempt to start again.