### PR TITLE
Support bounds attribute in photo.getByBounds for < 2.0 API compatibility

### DIFF
--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -801,6 +801,16 @@ Utils.geo = (function () {
     }
 
     /**
+     * Computes GeoJSON Poligon from bbox.
+     *
+     * @param {Array} bbox
+     * @returns {object} polygon GeoJSON Polygon geometry object
+     */
+    function bboxPoly(bbox) {
+        return turf.bboxPolygon(bbox).geometry;
+    }
+
+    /**
      * Compensate map distortion in polygon geometry object used in geospacial
      * query.
      *
@@ -856,6 +866,7 @@ Utils.geo = (function () {
         checkbbox,
         checkbboxLatLng,
         bboxReverse,
+        bboxPoly,
         polygonFixMapDistortion,
     };
 }());

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -2501,7 +2501,19 @@ async function save(data) {
  * @returns {object} object containing result.
  */
 function getByBounds(data) {
-    const { geometry, z, startAt } = data;
+    let { geometry, z, startAt, bounds } = data;
+
+    if (Array.isArray(bounds) && !geometry) {
+        // For pre 2.0 compatibility convert bbox to Poligon if bounds
+        // attribute is provided. We also set localWork for zooms 17 onwards
+        // like it used to be.
+        const bbox = _.flattenDeep(bounds);
+
+        if (Utils.geo.checkbboxLatLng(bbox)) {
+            geometry = Utils.geo.bboxPoly(Utils.geo.bboxReverse(bbox));
+            data.localWork = !(z < 17);
+        }
+    }
 
     if (!['MultiPolygon', 'Polygon'].includes(geometry.type) || !_.isNumber(z) || z < 1) {
         throw new BadParamsError();


### PR DESCRIPTION
This is basically restores bounds attribute (did no realise it was in use outside app frontend), so it can be used in API calls:
`https://pastvu.com/api2?method=photo.getByBounds&params={%22z%22:11,%22bounds%22:[[[37.401553,-122.91727],[37.96561,-121.758556]]]}`

I will update wiki once we released.

