### PR TITLE
Restrict photo.giveNearestPhotos distance

### DIFF
--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1936,7 +1936,7 @@ async function giveUserPhotosAround({ cid, limitL, limitR }) {
  * @param {number} obj.year
  * @param {number} obj.year2
  * @param {number} obj.except cid to exclude
- * @param {number} obj.distance distance in radians
+ * @param {number} obj.distance distance in meters (1000km max)
  * @param {number} obj.limit
  * @param {number} obj.skip
  * @returns {object[]} photos
@@ -1977,11 +1977,11 @@ async function giveNearestPhotos({ geo, type, year, year2, except, distance, lim
         query.cid = { $ne: except };
     }
 
-    if (_.isNumber(distance) && distance > 0 && distance < Math.PI) {
-        query.geo.$nearSphere.$maxDistance = Utils.geo.rad2meter(distance);
+    if (_.isNumber(distance) && distance > 0) {
+        query.geo.$nearSphere.$maxDistance = Math.min(1000000, distance);
     } else {
-        // By default restrict distance to hemisphere with the center at the point.
-        query.geo.$nearSphere.$maxDistance = Utils.geo.rad2meter(Math.PI / 2);
+        // By default restrict distance to 10km.
+        query.geo.$nearSphere.$maxDistance = 10000;
     }
 
     if (_.isNumber(limit) && limit > 0 && limit < 30) {


### PR DESCRIPTION
Since `nearSphere` is costly on long distances, especially in low points density areas, it would be reasonable to make it 10km by default when `photo.giveNearestPhotos` is called. It is used in "Nearest Photos" feed in photo view which does not require very distant photos.  Method was also in API use (although was not documented), we restrict max distance value to 1000km for the same reason.

Previously default distance from point was equal to hemisphere (PI/2 radians), to replicate, run on staging (takes ~20sec):
```
db.photos.find({"geo":{"$nearSphere":{"$geometry":{"type":"Point","coordinates":[-50.3265,82.9467]}, "$maxDistance": 10000000}},"s":5.0,"type":1.0,"year":{"$gte":1880,"$lte":1920}}, {limit: 12}).explain(true)
```
vs (~10ms)
```
db.photos.find({"geo":{"$nearSphere":{"$geometry":{"type":"Point","coordinates":[-50.3265,82.9467]}, "$maxDistance": 10000}},"s":5.0,"type":1.0,"year":{"$gte":1880,"$lte":1920}}, {limit: 12}).explain(true)
```
In both cases `2dsphere` index is used, but the first one seems involve too many stages as inner algorithm seems expanding the circle until required number of points is reached.
