### PR TITLE
Include OSM attribution in About page (RU)

### DIFF
--- a/public/style/diff/about.less
+++ b/public/style/diff/about.less
@@ -103,7 +103,7 @@
         .rotateY(180deg); /* back, initially hidden pane */
     }
 
-    .donate {
+    a {
         text-decoration: none;
         color: #ccd2da;
         border-width: 0 0 1px;

--- a/views/module/diff/about.pug
+++ b/views/module/diff/about.pug
@@ -53,12 +53,17 @@
     .postrow
         div
             | Открытая разработка ведется&nbsp;
-            a.donate(target="_blank", href="https://github.com/PastVu") на GitHub
+            a(target="_blank", href="https://github.com/PastVu") на GitHub
             | . Следите за выполнением задач и присылайте свои идеи!
     .postrow
         div(style="margin-top: 10px;")
             | Версия&nbsp;
             span(data-bind="text: version")
+    .postrow
+        div(style="margin-top: 10px;")
+            | Данные по границам географических и административных регионов: ©&nbsp;
+            a(target="_blank", href="https://www.openstreetmap.org/copyright") OpenStreetMap contributors
+            | .
     .postrow
         div.img(style="margin-top:15px;")
             img.poster(src="/img/loading/Loading1.jpg")


### PR DESCRIPTION
Adds OSM attribution per https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines

![image](https://user-images.githubusercontent.com/329780/152235914-8c086cfa-e965-4ffc-8eb8-9de214039a76.png)

(partialy addressing #402)