### PR TITLE
Include OSM attribution in About page (EN)

### DIFF
--- a/public/style/diff/about.less
+++ b/public/style/diff/about.less
@@ -103,7 +103,7 @@
         .rotateY(180deg); /* back, initially hidden pane */
     }
 
-    .donate {
+    a {
         text-decoration: none;
         color: #ccd2da;
         border-width: 0 0 1px;

--- a/views/module/diff/about.pug
+++ b/views/module/diff/about.pug
@@ -53,12 +53,17 @@
     .postrow
         div
             | Open development is performed&nbsp;
-            a.donate(target="_blank", href="https://github.com/PastVu") on GitHub
+            a(target="_blank", href="https://github.com/PastVu") on GitHub
             | . You may track for issues progress and send us your ideas!
     .postrow
         div(style="margin-top: 10px;")
             | Version&nbsp;
             span(data-bind="text: version")
+    .postrow
+        div(style="margin-top: 10px;")
+            | Administrative and geographic boundaries data: ©&nbsp;
+            a(target="_blank", href="https://www.openstreetmap.org/copyright") OpenStreetMap contributors
+            | .
     .postrow
         div.img(style="margin-top:15px;")
             img.poster(src="/img/loading/Loading1.jpg")


### PR DESCRIPTION
Same as #451 for `en` branch.
![image](https://user-images.githubusercontent.com/329780/152237063-1fdeebfa-8ea0-4488-a332-b6aef54c06f0.png)
