### PR TITLE
Include OSM attribution in API page and link to docs.

### DIFF
--- a/app/request.js
+++ b/app/request.js
@@ -252,7 +252,7 @@ export const handleHTTPAPIRequest = (function () {
         }
 
         if (_.isEmpty(query)) {
-            return res.set({ 'Cache-Control': 'no-cache' }).status(200).send('Welcome to PastVu Api');
+            return res.set({ 'Cache-Control': 'no-cache' }).status(200).render('api/api');
         }
 
         let params = query.params;

--- a/public/style/api/main.less
+++ b/public/style/api/main.less
@@ -1,0 +1,29 @@
+@import '../_vars.less';
+@import '../bs/variables.less';
+@import '../bs/mixins.less';
+
+body {
+    overflow-y: hidden;
+}
+
+.mainApi {
+    position: relative;
+    width: 100%;
+    padding: 0 6px;
+    border-top: 5px solid @MainBlueColor;
+
+    h3.titlelogo {
+        &::before {
+            background: url(/img/misc/logob.png) no-repeat;
+            float: left;
+            display: block;
+            height: 30px;
+            width: 30px;
+            background-size: 30px;
+            content: '';
+            margin-right: 5px;
+            margin-top: -4px;
+            margin-left: -2px;
+        }
+    }
+}

--- a/views/api/api.pug
+++ b/views/api/api.pug
@@ -1,0 +1,20 @@
+doctype html
+html
+    head
+        link(rel="stylesheet", href="/style/common.css")
+        link(rel="stylesheet", href="/style/api/main.css")
+        meta(http-equiv="content-type", content="text/html; charset=utf-8")
+        meta(http-equiv="X-UA-Compatible", content="IE=Edge")
+        meta(name="apple-mobile-web-app-capable", content="yes")
+        title PastVu API
+    body
+        div.mainApi
+            h3.titlelogo Welcome to PastVu API!
+            p(style="margin-top: 20px")
+                | See&nbsp;
+                a(target="_blank", href="https://github.com/PastVu/pastvu/wiki/API") API Reference
+                |  for docs and usage examples.
+            p
+                | Administrative and geographic boundaries data: ©&nbsp;
+                a(target="_blank", href="https://www.openstreetmap.org/copyright") OpenStreetMap contributors
+                | .


### PR DESCRIPTION
The `/api2` page will look like:
![image](https://user-images.githubusercontent.com/329780/152656314-908cb6a5-4e2c-4d0a-93c9-51a102d258b4.png)

Reference URL leads to https://github.com/PastVu/pastvu/wiki/API