### PR TITLE
docker: Hint about missing local config rather than create it.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ You need to have [docker](https://docs.docker.com/engine/install/) and [compose]
 docker compose up -d mongo
 # Import Pastvu database
 docker compose exec mongo initdb
+# Create config file
+cp ./config/local.config.js.docker-example ./config/local.config.js
 # Install node modules
 docker compose run --rm app npm install
 # Start the application

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -3,7 +3,10 @@ set -e
 
 CONFIG="./config/local.config.js"
 
-[ ! -f "${CONFIG}" ] && cp "${CONFIG}.docker-example" "${CONFIG}"
+if [ ! -f "${CONFIG}" ]; then
+  echo "${CONFIG} is missing. Create one by running 'cp ${CONFIG}.docker-example ${CONFIG} "
+  exit 1;
+fi
 
 # 'run MODULE [options]' special command to run script directly with node, so that system signals are relayed to the process.
 if [ "$1" = 'run' -a -f "./${2}.js" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "pastvu",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "dependencies": {
                 "@mapbox/geojson-area": "0.2.2",
                 "@mapbox/geojson-rewind": "0.5.0",


### PR DESCRIPTION
In some systems this may cause permission error (I can't replicate that in Debian Bullseye and latest Docker), it is better to be explicit about how to create a config file.

Fixes: #467