### PR TITLE
Use constants for user ranks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,13 @@ supply your contribution along with tests where posible. To run tests locally,
 execute `npm run jest`. If you need to supply any [CLI
 options](https://jestjs.io/docs/cli), call it as `npm run jest -- --verbose=true`.
 
+In order to run test with a name that matches the regex, use `-t` (alias of
+`--testNamePattern=<regex>`) param. For example, to run tests containing 'auth' in the name execute:
+
+```
+npm run jest -- --verbose=true -t auth
+```
+
 You can also run entire test suite by executing `npm test`. This will include
 linters run to verify coding style.
 

--- a/controllers/__tests__/profile.test.js
+++ b/controllers/__tests__/profile.test.js
@@ -1,0 +1,61 @@
+import profile from '../profile';
+import { User } from '../../models/User';
+import { BadParamsError, AuthorizationError } from '../../app/errors';
+import testHelpers from '../../tests/testHelpers';
+
+jest.mock('../mail');
+
+describe('profile', () => {
+    describe('save user ranks', () => {
+        beforeEach(async () => {
+            // Register user and confirm.
+            await testHelpers.createUser({ login: 'user1', pass: 'pass1' });
+
+            // Mock non-registerd user handshake.
+            profile.handshake = { 'usObj': { 'isAdmin': true } };
+        });
+
+        afterEach(() => {
+            // Delete handshake.
+            delete profile.handshake;
+        });
+
+        it('should save ranks', async () => {
+            expect.assertions(2);
+
+            // Save user ranks.
+            const ranks = ['mec'];
+            const result = await profile.saveUserRanks({ 'login': 'user1', 'ranks': ranks });
+
+            // Convert CoreMongooseArray to array.
+            result.ranks = Array.from(result.ranks);
+
+            expect(result).toStrictEqual({ 'saved': true, 'ranks': ranks });
+
+            // Check record.
+            const user = await User.findOne({ 'login': 'user1' });
+
+            expect(Array.from(user.ranks)).toStrictEqual(ranks);
+        });
+
+        it('throws on missing login', async () => {
+            expect.assertions(1);
+            await expect(profile.saveUserRanks({ 'ranks': [] })).rejects.toThrow(new BadParamsError());
+        });
+
+        it('throws on non-existing or malformed ranks', async () => {
+            expect.assertions(3);
+            await expect(profile.saveUserRanks({ 'login': 'user1', 'ranks': undefined })).rejects.toThrow(new BadParamsError());
+            await expect(profile.saveUserRanks({ 'login': 'user1', 'ranks': ['blabla'] })).rejects.toThrow(new BadParamsError());
+            await expect(profile.saveUserRanks({ 'login': 'user1', 'ranks': ['mec', 'blabla'] })).rejects.toThrow(new BadParamsError());
+        });
+
+        it('throws on unauthorised access', async () => {
+            expect.assertions(1);
+
+            profile.handshake.usObj.isAdmin = false;
+
+            await expect(profile.saveUserRanks({ 'login': 'user1', 'ranks': ['mec'] })).rejects.toThrow(new AuthorizationError());
+        });
+    });
+});

--- a/controllers/constants.js
+++ b/controllers/constants.js
@@ -41,4 +41,10 @@ export default {
         watersignLength: 65,
         watersignPattern: /[\w.,:;()[\]\\|/№§©®℗℠™•?!@#$%^&*+\-={}"'<>~` ]/g,
     },
+
+    user: {
+        ranks: [
+            'mec', 'mec_silv', 'mec_gold', 'adviser',
+        ],
+    },
 };

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -13,7 +13,7 @@ import constants from './constants.js';
 import * as photoController from './photo';
 import { userThrottleChange } from './subscr';
 import constantsError from '../app/errors/constants';
-import { userSettingsDef, userSettingsVars, userRanksHash } from './settings';
+import { userSettingsDef, userSettingsVars } from './settings';
 import { AuthenticationError, AuthorizationError, BadParamsError, InputError, NotFoundError } from '../app/errors';
 
 import { User } from '../models/User';
@@ -529,7 +529,7 @@ async function saveUserRanks({ login, ranks }) {
 
     // Check that all values are allowed
     for (const rank of ranks) {
-        if (!userRanksHash[rank]) {
+        if (!constants.user.ranks.includes(rank)) {
             throw new BadParamsError();
         }
     }

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -2,14 +2,13 @@ import config from '../config';
 import { waitDb } from './connection';
 import { Settings } from '../models/Settings';
 import { UserSettings } from '../models/UserSettings';
+import constants from './constants';
 
 export const clientParams = {};
 export const userSettingsDef = {};
 export const userSettingsVars = {};
-export const userRanksHash = {};
-export let userRanks;
 
-export const ready = waitDb.then(() => Promise.all([fillClientParams(), fillUserSettingsDef(), fillUserRanks()]));
+export const ready = waitDb.then(() => Promise.all([fillClientParams(), fillUserSettingsDef()]));
 
 const clientParamsPromise = Promise.resolve(clientParams);
 const getClientParams = () => clientParamsPromise;
@@ -17,8 +16,7 @@ const getClientParams = () => clientParamsPromise;
 const userSettingsVarsPromise = Promise.resolve(userSettingsVars);
 const getUserSettingsVars = () => userSettingsVarsPromise;
 
-let userRanksPromise;
-const getUserRanks = () => userRanksPromise;
+const getUserRanks = () => constants.user.ranks;
 
 // Fill object for client parameters
 async function fillClientParams() {
@@ -34,26 +32,11 @@ async function fillClientParams() {
 
 // Fill object of default user settings
 async function fillUserSettingsDef() {
-    const settings = await UserSettings.find(
-        { key: { $ne: 'ranks' } },
-        { _id: 0, key: 1, val: 1, vars: 1 }, { lean: true }
-    ).exec();
+    const settings = await UserSettings.find({}, { _id: 0, key: 1, val: 1, vars: 1 }, { lean: true }).exec();
 
     for (const setting of settings) {
         userSettingsDef[setting.key] = setting.val;
         userSettingsVars[setting.key] = setting.vars;
-    }
-}
-
-// Fill object of user ranks
-async function fillUserRanks() {
-    const row = await UserSettings.findOne({ key: 'ranks' }, { _id: 0, vars: 1 }, { lean: true }).exec();
-
-    userRanks = row?.vars || [];
-    userRanksPromise = Promise.resolve(userRanks);
-
-    for (const rank of userRanks) {
-        userRanksHash[rank] = 1;
     }
 }
 

--- a/migrations/20220611144215-remove_ranks_settings.js
+++ b/migrations/20220611144215-remove_ranks_settings.js
@@ -1,0 +1,12 @@
+/**
+ * Remove ranks from the settings collection. This is now defined as constant.
+ */
+module.exports = {
+    async up(db/*, client*/) {
+        await db.collection('user_settings').deleteOne({ key: 'ranks' });
+    },
+
+    async down(db/*, client*/) {
+        await db.collection('user_settings').insertOne({ key: 'ranks', vars: ['mec', 'mec_silv', 'mec_gold', 'adviser'], desc: 'Звания пользователя' });
+    },
+};

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -51,7 +51,6 @@ async function seedDatabase() {
     await UserSettings.insertMany([
         { key: 'subscr_auto_reply', val: true, vars: [true, false], desc: 'Автоподписка при комментировании темы' },
         { key: 'subscr_throttle', val: 3 * 60 * 60 * 1000, vars: [5 * 60 * 1000, 30 * 60 * 1000, 60 * 60 * 1000, 3 * 60 * 60 * 1000, 6 * 60 * 60 * 1000, 24 * 60 * 60 * 1000], desc: 'Минимальный интервал между отправками письма с уведомлением' },
-        { key: 'ranks', vars: ['mec', 'mec_silv', 'mec_gold', 'adviser'], desc: 'Звания пользователя' },
         { key: 'r_f_photo_user_gal', val: true, vars: [true, false], desc: 'Фильтровать галерею пользователя на странице фото' },
         { key: 'r_f_user_gal', val: true, vars: [true, false], desc: 'Фильтровать галерею пользователя в его профиле' },
         { key: 'r_as_home', val: false, vars: [true, false], desc: 'Регион для фильтрации по умолчанию берётся из домашнего региона' },


### PR DESCRIPTION
Define user ranks in constants rather than database.
 Given language string are hardcoded anyway and some of those ranks are
used explicitly in the code to modify upload limits, it is better to keep them in constants.