### PR TITLE
Suspend email notifications

### DIFF
--- a/controllers/__tests__/auth.test.js
+++ b/controllers/__tests__/auth.test.js
@@ -6,8 +6,6 @@ import constants from '../../app/errors/constants';
 import auth from '../auth';
 import testHelpers from '../../tests/testHelpers';
 
-jest.mock('../mail');
-
 describe('authentication', () => {
     beforeAll(() => {
         // Mocking this.call for auth.

--- a/controllers/__tests__/profile.test.js
+++ b/controllers/__tests__/profile.test.js
@@ -3,8 +3,6 @@ import { User } from '../../models/User';
 import { BadParamsError, AuthorizationError } from '../../app/errors';
 import testHelpers from '../../tests/testHelpers';
 
-jest.mock('../mail');
-
 describe('profile', () => {
     describe('save user ranks', () => {
         beforeEach(async () => {

--- a/controllers/__tests__/subscr.test.js
+++ b/controllers/__tests__/subscr.test.js
@@ -3,8 +3,6 @@ import { UserObjectRel, UserNoty } from '../../models/UserStates';
 import subscr, { commentAdded, commentViewed } from '../subscr';
 import testHelpers from '../../tests/testHelpers';
 
-jest.mock('../mail');
-
 describe('subscription', () => {
     describe('get subscription object relations for given user', () => {
         let user;

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -150,7 +150,8 @@ export async function commentAdded(objId, user, stamp = new Date()) {
         { $set: { sbscr_noty_change: stamp, sbscr_noty: true } }
     ).exec();
 
-    scheduleUserNotice(users); // Call scheduler of notification sending for subscribed users
+    // Schedule notification sending for subscribed users.
+    await scheduleUserNotice(users);
 
     return users;
 }

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -130,7 +130,7 @@ export async function commentAdded(objId, user, stamp = new Date()) {
         { obj: objId, user: { $ne: user._id }, sbscr_create: { $exists: true }, sbscr_noty: { $exists: false } },
         { _id: 1, user: 1 },
         { lean: true }
-    ).exec();
+    ).populate({ path: 'user', select: { _id: 1, nologin: 1, 'settings.subscr_disable_noty': 1 } }).exec();
 
     if (_.isEmpty(objs)) {
         return []; // If no one is subscribed to object - exit
@@ -140,8 +140,12 @@ export async function commentAdded(objId, user, stamp = new Date()) {
     const users = [];
 
     for (const obj of objs) {
-        ids.push(obj._id);
-        users.push(obj.user);
+        // Don't schedule notification if user is not permitted to login or
+        // notifications are disabled in user preferences.
+        if (!(obj.user.nologin || obj.user.settings.subscr_disable_noty)) {
+            ids.push(obj._id);
+            users.push(obj.user._id);
+        }
     }
 
     // Set flag of readiness of notification by object for subscribed users
@@ -210,6 +214,21 @@ export async function userThrottleChange(userId, newThrottle) {
         nearestNoticeTimeStamp;
 
     await UserNoty.updateOne({ user: userId }, { $set: { nextnoty: new Date(newNextNoty) } }).exec();
+}
+
+/**
+ * Cancel all scheduled notifications.
+ *
+ * @param {ObjectId} userId
+ */
+export async function userCancelNotifications(userId) {
+    // Reset notifications ready to send flag.
+    await UserObjectRel.updateMany(
+        { user: userId },
+        { $unset: { sbscr_noty: 1 }, $set: { sbscr_noty_change: new Date() } }
+    ).exec();
+    // Reset scheduled sending to user.
+    await UserNoty.updateOne({ user: userId }, { $unset: { nextnoty: 1 } }).exec();
 }
 
 /**

--- a/migrations/20220626195643-add_user_setting_subscr_disable_noty.js
+++ b/migrations/20220626195643-add_user_setting_subscr_disable_noty.js
@@ -1,0 +1,13 @@
+/**
+ * Create new user setting subscr_disable_noty
+ */
+module.exports = {
+    async up(db/*, client*/) {
+        await db.collection('user_settings').insertOne({ key: 'subscr_disable_noty', val: false, vars: [true, false], desc: 'Присылать уведомления по электронной почте' });
+    },
+
+    async down(db/*, client*/) {
+        await db.collection('user_settings').deleteOne({ key: 'subscr_disable_noty' });
+    },
+};
+

--- a/public/js/module/user/settings.js
+++ b/public/js/module/user/settings.js
@@ -341,6 +341,9 @@ define([
                 this.changeSetting('subscr_throttle', Number(val));
             }
         },
+        disableNoty: function (data, evt) {
+            this.changeSetting('subscr_disable_noty', !isYes(evt), true);
+        },
         changeSetting: function (key, val, checkValChange, cb, ctx) {
             if (!this.u.settings[key] || (checkValChange && val === this.u.settings[key]())) {
                 return;

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -60,5 +60,6 @@ async function seedDatabase() {
         { key: 'photo_filter_type', val: [1, 2], vars: [1, 2], desc: 'Default filtering by photos type' },
         { key: 'comment_show_deleted', val: false, vars: [true, false], desc: 'Показывать удаленные комментарии' },
         { key: 'photo_disallow_download_origin', val: false, vars: [true, false], desc: 'Disallow others users to download photo without watermark' },
+        { key: 'subscr_disable_noty', val: false, vars: [true, false], desc: 'Присылать уведомления по электронной почте' },
     ]);
 }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import { UserSettings } from '../models/UserSettings';
 
 jest.setTimeout(10000);
+jest.mock('../controllers/mail');
 
 // Runs before any of the tests in test file run.
 beforeAll(async () => {

--- a/tests/testHelpers.js
+++ b/tests/testHelpers.js
@@ -1,8 +1,6 @@
 import { User, UserConfirm } from '../models/User';
 import auth from '../controllers/auth';
 
-jest.mock('../controllers/mail');
-
 /**
  * Create test user using auth controller for consistency.
  *

--- a/views/module/user/settings.pug
+++ b/views/module/user/settings.pug
@@ -334,11 +334,26 @@
                     .help.tltp-wrap
                         span.glyphicon.glyphicon-info-sign
                         .tltp.tltp-top.tltp-animate-move
+                            | При отключенной опции уведомления на эл. почту приходить не будут.
+                            br
+                            | При включении, уведомления будут приходить на комментарии,
+                            br
+                            | созданные с момента включения опции.
+                    | &nbsp;Присылать уведомления
+                dd
+                    .btn-group.btn-group-sm
+                        button.btn.btn-primary.yes(type="button", data-bind="css: {active: !u.settings.subscr_disable_noty()}, click: disableNoty") Да
+                        button.btn.btn-primary.no(type="button", data-bind="css: {active: u.settings.subscr_disable_noty()}, click: disableNoty") Нет
+            dl.dl-horizontal
+                dt.helpexists
+                    .help.tltp-wrap
+                        span.glyphicon.glyphicon-info-sign
+                        .tltp.tltp-top.tltp-animate-move
                             | Минимальное время, которое должно пройти
                             br
                             | между отправками писем с уведомлением
                     | &nbsp;Минимальный интервал между отправками
                 dd.throttle(data-bind="foreach: vars.subscr_throttle")
                     label.radio-inline
-                        input(type="radio", name="subscr_throttle_radios", data-bind="attr: {id: 'subscr_throttle_radios_' + $index(), value: ''+$data}, checked: $parent.u.settings.subscr_throttle")
+                        input(type="radio", name="subscr_throttle_radios", data-bind="attr: {disabled: $parent.u.settings.subscr_disable_noty(), id: 'subscr_throttle_radios_' + $index(), value: ''+$data}, checked: $parent.u.settings.subscr_throttle")
                         span(data-bind="text: ($data/60000 > 59 ? $data/3600000 + 'ч' : $data/60000 + 'мин')")


### PR DESCRIPTION
Add a setting that allows user to disable email notifications. When re-enabled, only notification about comments created from this moment will be sent.

Disabling notifications cancels all scheduled notifications that exists at this point, i.e. disabling has immedaite effect and user will not receive any notification emails after disabling even if comment to subscribed item was made before notifications were disabled.

This also disables notifcations for user without permission to login (it does not change notification setting, we just don't send anything to users with `nologin` flag).

For screenshots, see https://github.com/PastVu/pastvu/issues/122#issuecomment-1171093881