### PR TITLE
styles: Fix long upload filename overflow.

### DIFF
--- a/public/style/user/photoUpload.less
+++ b/public/style/user/photoUpload.less
@@ -92,8 +92,8 @@
         background-color: #2171cc;
     }
 
-    .filesTable {
-        td.preview {
+    .filesTable td {
+        &.preview {
             width: 210px;
 
             .forcanvas {
@@ -127,8 +127,11 @@
             }
         }
 
-        td.fileButtons {
-            width: 150px;
+        &.desc {
+            overflow-wrap: anywhere;
+        }
+
+        &.fileButtons {
             text-align: right;
             white-space: nowrap;
         }


### PR DESCRIPTION
Fixes #478 per screenshot (enables long file names wrapping):
![image](https://user-images.githubusercontent.com/329780/177055568-27513b86-92e4-491d-9f3e-6f74bb5a315c.png)


