### PR TITLE
socket: Remove remaning socket.binary use.

### DIFF
--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -608,7 +608,7 @@ export async function loginUser({ user }) {
     // Send user to all sockets of session, except current socket (auth-controller will send user there)
     _.forOwn(sessionNew.sockets, sock => {
         if (sock !== socket && _.isFunction(sock.emit)) {
-            sock.binary(false).emit('youAre', { user: userPlain, registered: true });
+            sock.emit('youAre', { user: userPlain, registered: true });
         }
     });
 


### PR DESCRIPTION
Overlooked another socket.binary use, this has been deprecated in dfe5dd5 (#484).