### PR TITLE
Fix comments zero level input subscription status

### DIFF
--- a/public/js/module/comment/comments.js
+++ b/public/js/module/comment/comments.js
@@ -172,7 +172,7 @@ define([
                 this.show();
             }
         },
-        deactivate: function () {
+        deactivate: function (isNewCid) {
             if (!this.showing) {
                 return;
             }
@@ -183,10 +183,18 @@ define([
             this.inViewport = false;
 
             if (this.auth.loggedIn() && this.showTree()) {
-                //Если зарегистрированы и уже есть комментарии, надо вынуть ответ первого уровня из dom,
-                //и положить после рендеринга заново, т.к. рендеринг заменяет innerHTML блока комментариев
-                this.inputZeroDetach();
-                //Удаляем через jquery остальные возможные поля ввода, чтобы снять с них события
+                if (isNewCid) {
+                    // Loading new photo or news item. Delete zero level input, to have it rendered again
+                    // to reflect subscription status of the new item.
+                    if (this.cZeroDetached) {
+                        this.cZeroDetached.remove();
+                    }
+                    this.cZeroCreated = false;
+                } else {
+                    // Likely photo page editing happens, detach zero level input and re-add it later.
+                    this.inputZeroDetach();
+                }
+                // Delete all comment inputs through jquery to detach events.
                 $('.cadd', this.$cmts).remove();
             }
             this.$cmts[0].innerHTML = ''; //Просто очищаем контент, чтобы при дестрое модуля jquery не пробегал по всем элеменат в поисках данных для удаления

--- a/public/js/module/diff/news.js
+++ b/public/js/module/diff/news.js
@@ -84,7 +84,7 @@ define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mappin
             }
 
             if (!this.news || (this.news && Utils.isType('function', this.news.cid) && this.news.cid() !== cid)) {
-                this.commentsVM.deactivate();
+                this.commentsVM.deactivate(true);
 
                 this.getNews(cid, function (data) {
                     Utils.title.setTitle({ title: data.news.title });

--- a/public/js/module/photo/photo.js
+++ b/public/js/module/photo/photo.js
@@ -383,7 +383,7 @@ define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mappin
 
             if (self.p && _.isFunction(self.p.cid) && self.p.cid() !== cid) {
                 self.photoLoading(true);
-                self.commentsVM.deactivate();
+                self.commentsVM.deactivate(true);
 
                 this.receivePhoto(cid, false, function (data) {
                     var editModeCurr = self.edit();


### PR DESCRIPTION
Make sure input container is not preserved when comments are deactivated as result of routing to new item. It should be rendered again in this case to reflect current item subscription status correctly.

Fixes #99