### PR TITLE
License project under AGPLv3+

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 module.exports = {
     'root': true,
     'parser': '@babel/eslint-parser',
@@ -28,6 +33,7 @@ module.exports = {
 
     'plugins': [
         '@babel',
+        'header',
     ],
 
     'extends': [
@@ -681,6 +687,12 @@ module.exports = {
         '@babel/no-invalid-this': 0,
         '@babel/semi': 2,
         '@babel/no-unused-expressions': 2, // Stop complaining about optional chaining
+        'header/header': [2, 'block', [
+            '*',
+            ' * Copyright: The PastVu contributors.',
+            ' * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)',
+            ' ',
+        ], 2],
     },
     'overrides': [
         {
@@ -723,6 +735,14 @@ module.exports = {
                 'no-underscore-dangle': [2, { 'allow': [
                     '_id', '__get__', '__set__', '__RewireAPI__', '__Rewire__', '__ResetDependency__', '__GetDependency__',
                 ] }],
+            },
+        },
+        {
+            // Example configuration files.
+            'files': ['config/*example'],
+            'rules': {
+                // no copyright header required.
+                'header/header': 0,
             },
         },
     ],

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 module.exports = {
     'extends': 'stylelint-config-standard',
     'ignoreFiles': ['**/*.{eot,ttf,woff}'],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ Our [contributing guide](https://docs.pastvu.com/en/contributing) contains more 
 
 Contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).
 
+## Licensing
+
+By contributing to PastVu, you agree that your contributions will be licensed under its AGPLv3 license.
+
 ## Quick start
 
 Just [setup dev environment](https://docs.pastvu.com/en/dev/setup) and pick something from the list of [good first issues](https://github.com/PastVu/pastvu/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to work on. Each of those tasks are relatively simple and will help you to get familiar with a project code and structure.

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 'use strict';
 
 module.exports = function (grunt) {

--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ We expect all project participants to follow [Contributor Code of Conduct](CODE_
 
 ## License
 
+* GNU Affero General Public License (AGPL) v3 or later. See [COPYING](https://github.com/pastvu/pastvu/blob/master/COPYING) for the full license text.
 * Test database used for development setup is licensed under [ODbL 1.0](https://opendatacommons.org/licenses/odbl/summary/), geographic and adminstrative boundaries data it contains: © [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors.
 

--- a/api.js
+++ b/api.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 'use strict';
 
 const express = require('express');

--- a/app.js
+++ b/app.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import http from 'http';
 import path from 'path';

--- a/app/errors/Application.js
+++ b/app/errors/Application.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import http from 'http';
 import errorMsgs from './intl';

--- a/app/errors/Authentication.js
+++ b/app/errors/Authentication.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/Authorization.js
+++ b/app/errors/Authorization.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/BadParams.js
+++ b/app/errors/BadParams.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/Input.js
+++ b/app/errors/Input.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/NotFound.js
+++ b/app/errors/NotFound.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/Notice.js
+++ b/app/errors/Notice.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import constants from './constants';
 import ApplicationError from './Application';

--- a/app/errors/Timeout.js
+++ b/app/errors/Timeout.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import errorMsgs from './intl';

--- a/app/errors/__tests__/ApplicationError.test.js
+++ b/app/errors/__tests__/ApplicationError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { ApplicationError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/AuthenticationError.test.js
+++ b/app/errors/__tests__/AuthenticationError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { AuthenticationError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/AuthorizationError.test.js
+++ b/app/errors/__tests__/AuthorizationError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { AuthorizationError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/BadParamsError.test.js
+++ b/app/errors/__tests__/BadParamsError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { BadParamsError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/InputError.test.js
+++ b/app/errors/__tests__/InputError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { InputError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/NotFoundError.test.js
+++ b/app/errors/__tests__/NotFoundError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { NotFoundError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/NoticeError.test.js
+++ b/app/errors/__tests__/NoticeError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { NoticeError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/__tests__/TimeoutError.test.js
+++ b/app/errors/__tests__/TimeoutError.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { TimeoutError } from '../';
 import constants from '../constants';
 import errorMsgs from '../intl';

--- a/app/errors/constants.js
+++ b/app/errors/constants.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import Utils from '../../commons/Utils';
 
 export default Utils.reflectKeys({

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 export { default as ApplicationError } from './Application';
 export { default as AuthenticationError } from './Authentication';
 export { default as AuthorizationError } from './Authorization';

--- a/app/errors/intl.js
+++ b/app/errors/intl.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 export default {
     DENY: 'У вас нет прав на это действие',
 

--- a/app/request.js
+++ b/app/request.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import http from 'http';
 import util from 'util';

--- a/app/webapi/client.js
+++ b/app/webapi/client.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /*
 const _ = require('lodash');
 const ms = require('ms');

--- a/app/webapi/methods.js
+++ b/app/webapi/methods.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 export { default as auth } from '../../controllers/auth';
 export { default as admin } from '../../controllers/admin';
 export { default as index } from '../../controllers/index';

--- a/app/webapi/server.js
+++ b/app/webapi/server.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import util from 'util';
 import log4js from 'log4js';

--- a/babel/server.config.js
+++ b/babel/server.config.js
@@ -1,7 +1,9 @@
 /**
- * Babel configuration for nodejs server.
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
 
+// Babel configuration for nodejs server.
 module.exports = {
     comments: false,
     presets: [

--- a/babel/server.files.js
+++ b/babel/server.files.js
@@ -1,6 +1,9 @@
 /**
- * List of files to compile
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
+// List of files to compile.
 module.exports = {
     only: [ // May be array of regexp, or github.com/isaacs/node-glob
         /(app|downloader|uploader|sitemap|notifier|worker).js/,

--- a/babel/transform.js
+++ b/babel/transform.js
@@ -1,4 +1,9 @@
 #! /usr/bin/env node
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 'use strict';
 
 const fs = require('fs');

--- a/build.js
+++ b/build.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 'use strict';
 
 require('./bin/run');

--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 const fs = require('fs');
 const path = require('path');
 const config = require('../config');

--- a/config/browsers.config.js
+++ b/config/browsers.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 module.exports = function (config/* , appRequire */) {
     config.browsers = {
 

--- a/config/client.js
+++ b/config/client.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 module.exports = window.App.config;

--- a/config/default.config.js
+++ b/config/default.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 // Default server configuration
 const ms = require('ms');
 

--- a/config/log4js.js
+++ b/config/log4js.js
@@ -1,7 +1,9 @@
 /**
- * Log4js configuration.
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
 
+// Log4js configuration.
 const path = require('path');
 const _ = require('lodash');
 const makeDir = require('make-dir');

--- a/config/migrate-mongo.js
+++ b/config/migrate-mongo.js
@@ -1,6 +1,9 @@
 /**
- * Migrate-mongo configuration.
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
+// Migrate-mongo configuration.
 const mongoConfig = require('./').mongo;
 const argv = require('yargs').argv;
 const logger = require('log4js').getLogger('migrate-mongo');

--- a/config/server.js
+++ b/config/server.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Module for assembling configuration object on server
  * Configuration with all default parameters is located in 'config/default.config.js'
  *

--- a/controllers/__mocks__/mail.js
+++ b/controllers/__mocks__/mail.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 // Mock mailing setup and sending functions.
 export const send = jest.fn().mockResolvedValue();
 export const ready = jest.fn().mockResolvedValue();

--- a/controllers/__tests__/auth.test.js
+++ b/controllers/__tests__/auth.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import { User, UserConfirm } from '../../models/User';
 import { send } from '../mail';

--- a/controllers/__tests__/profile.test.js
+++ b/controllers/__tests__/profile.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import profile from '../profile';
 import { User } from '../../models/User';
 import { BadParamsError, AuthorizationError } from '../../app/errors';

--- a/controllers/__tests__/subscr.test.js
+++ b/controllers/__tests__/subscr.test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import { UserObjectRel, UserNoty } from '../../models/UserStates';
 import subscr, { commentAdded, commentViewed } from '../subscr';

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import log4js from 'log4js';

--- a/controllers/actionlog.js
+++ b/controllers/actionlog.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { ActionLog } from '../models/ActionLog';
 
 export const OBJTYPES = {

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import * as sessionController from './_session';
 import constantsError from '../app/errors/constants';

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /* eslint-disable no-throw-literal, prefer-promise-reject-errors */
 
 import ms from 'ms';

--- a/controllers/apilog.js
+++ b/controllers/apilog.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import log4js from 'log4js';
 import { waitDb } from './connection';
 import { ApiLog } from '../models/ApiLog';

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { promises as fsAsync } from 'fs';
 import ms from 'ms';
 import _ from 'lodash';

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import log4js from 'log4js';
 import Utils from '../commons/Utils';

--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import log4js from 'log4js';

--- a/controllers/connection.js
+++ b/controllers/connection.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import log4js from 'log4js';
 import { ApplicationError } from '../app/errors';

--- a/controllers/constants.js
+++ b/controllers/constants.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 export default {
     region: {
         maxLevel: 5, // 6 levels of regions: 0..5

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { promises as fsAsync } from 'fs';
 import ms from 'ms';
 import gm from 'gm';

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import moment from 'moment';

--- a/controllers/mail.js
+++ b/controllers/mail.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import log4js from 'log4js';
 import config from '../config';

--- a/controllers/middleware.js
+++ b/controllers/middleware.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import fs, { promises as fsAsync } from 'fs';
 import path from 'path';

--- a/controllers/migration.js
+++ b/controllers/migration.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import log4js from 'log4js';
 import ms from 'ms';
 import migrate from 'migrate-mongo';

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import fs from 'fs';
 import ms from 'ms';
 import mv from 'mv';

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import fs from 'fs';
 import gm from 'gm';
 import mv from 'mv';

--- a/controllers/queue.js
+++ b/controllers/queue.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import log4js from 'log4js';
 import config from '../config';
 import Queue from 'bull';

--- a/controllers/reason.js
+++ b/controllers/reason.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import { waitDb } from './connection';
 import { Reason } from '../models/Reason';

--- a/controllers/region.js
+++ b/controllers/region.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import log4js from 'log4js';

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import http from 'http';
 import log4js from 'log4js';

--- a/controllers/serviceConnector.js
+++ b/controllers/serviceConnector.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import net from 'net';
 import { handleServiceRequest } from '../app/request';
 import exitHook from 'async-exit-hook';

--- a/controllers/serviceConnectorPlug.js
+++ b/controllers/serviceConnectorPlug.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import net from 'net';
 import EventEmitter from 'events';
 

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import config from '../config';
 import { waitDb } from './connection';
 import { Settings } from '../models/Settings';

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { promises as fsAsync } from 'fs';
 import _ from 'lodash';
 import path from 'path';

--- a/controllers/systemjs.js
+++ b/controllers/systemjs.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /* eslint no-var: 0, object-shorthand: [2, 'never'] */
 /* global linkifyUrlString: true, toPrecision: true, toPrecision6: true, toPrecisionRound:true, geoToPrecision:true,
    regionClearPhotoTitle:true, regionsAssignPhotos:true, regionsAssignComments:true, calcPhotoStats:true, calcUserStats:true

--- a/controllers/tpl.js
+++ b/controllers/tpl.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import path from 'path';
 import Utils from '../commons/Utils';
 

--- a/controllers/userobjectrel.js
+++ b/controllers/userobjectrel.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import log4js from 'log4js';
 

--- a/downloader.js
+++ b/downloader.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import fs, { promises as fsAsync } from 'fs';
 import ms from 'ms';
 import _ from 'lodash';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 module.exports = {
     testEnvironment: 'node',
     transform: {

--- a/migrations/20210524112904-replace_2d_with_2dsphere.js
+++ b/migrations/20210524112904-replace_2d_with_2dsphere.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Replace 2d index with 2dsphere for support of geospacial queries on a
  * sphere.
  */

--- a/migrations/20220611144215-remove_ranks_settings.js
+++ b/migrations/20220611144215-remove_ranks_settings.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Remove ranks from the settings collection. This is now defined as constant.
  */
 module.exports = {

--- a/migrations/20220626195643-add_user_setting_subscr_disable_noty.js
+++ b/migrations/20220626195643-add_user_setting_subscr_disable_noty.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Create new user setting subscr_disable_noty
  */
 module.exports = {

--- a/models/ActionLog.js
+++ b/models/ActionLog.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/ApiLog.js
+++ b/models/ApiLog.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Cluster.js
+++ b/models/Cluster.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import constants from '../controllers/constants';
 import { registerModel } from '../controllers/connection';

--- a/models/Counter.js
+++ b/models/Counter.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Download.js
+++ b/models/Download.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/News.js
+++ b/models/News.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Photo.js
+++ b/models/Photo.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import _ from 'lodash';
 import { Schema } from 'mongoose';
 import constants from '../controllers/constants';

--- a/models/Reason.js
+++ b/models/Reason.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Region.js
+++ b/models/Region.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Sessions.js
+++ b/models/Sessions.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/Settings.js
+++ b/models/Settings.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/User.js
+++ b/models/User.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import _ from 'lodash';
 import bcrypt from 'bcrypt';

--- a/models/UserAction.js
+++ b/models/UserAction.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/UserSettings.js
+++ b/models/UserSettings.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/UserStates.js
+++ b/models/UserStates.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Schema } from 'mongoose';
 import { registerModel } from '../controllers/connection';
 

--- a/models/_initValues.js
+++ b/models/_initValues.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { Model } from 'mongoose';
 import { Settings } from './Settings';
 import { waitDb } from '../controllers/connection';

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 const mongoose = require('mongoose');
 
 mongoose.Query.prototype.paginate = function paginate(page, limit, cb) {

--- a/notifier.js
+++ b/notifier.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import moment from 'moment';
 import log4js from 'log4js';
 import config from './config';

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
                 "babel-jest": "27.3.1",
                 "babel-plugin-rewire": "1.2.0",
                 "eslint": "7.24.0",
+                "eslint-plugin-header": "3.1.1",
                 "eslint-plugin-jest": "25.3.0",
                 "eslint-plugin-jest-formatting": "3.1.0",
                 "eslint-plugin-jsdoc": "32.3.0",
@@ -6809,6 +6810,15 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-plugin-header": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+            "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+            "dev": true,
+            "peerDependencies": {
+                "eslint": ">=7.7.0"
             }
         },
         "node_modules/eslint-plugin-jest": {
@@ -22771,6 +22781,13 @@
                     "dev": true
                 }
             }
+        },
+        "eslint-plugin-header": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+            "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-jest": {
             "version": "25.3.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
         "babel-jest": "27.3.1",
         "babel-plugin-rewire": "1.2.0",
         "eslint": "7.24.0",
+        "eslint-plugin-header": "3.1.1",
         "eslint-plugin-jest": "25.3.0",
         "eslint-plugin-jest-formatting": "3.1.0",
         "eslint-plugin-jsdoc": "32.3.0",

--- a/public/js/EventTypes.js
+++ b/public/js/EventTypes.js
@@ -1,6 +1,8 @@
 /**
- * Event Types
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['Browser'], function (Browser) {
     return {
         mup: Browser.support.touch ? 'touchend' : 'mouseup',

--- a/public/js/Locations.js
+++ b/public/js/Locations.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['jquery', 'Browser', 'knockout.mapping', 'Params'/*, 'http://www.geoplugin.net/javascript.gp'*/], function ($, Browser, koMapping, P) {
     'use strict';
 

--- a/public/js/Params.js
+++ b/public/js/Params.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /*global init:true*/
 /**
  * Params

--- a/public/js/_mainConfig.js
+++ b/public/js/_mainConfig.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /*global requirejs:true*/
 requirejs.config({
     baseUrl: '/js',

--- a/public/js/errors/Application.js
+++ b/public/js/errors/Application.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['Utils'], function (Utils) {
     const CAPTURE_STACK_TRACE_SUPPORT = Boolean(Error.captureStackTrace);
     const FIREFOX_ERROR_INFO = /@(.+?):(\d+):(\d+)$/;

--- a/public/js/errors/Timeout.js
+++ b/public/js/errors/Timeout.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['Utils', 'errors/Application'], function (Utils, ApplicationError) {
     function TimeoutError(event, timeout) {
         TimeoutError.superproto.constructor.call(this);

--- a/public/js/globalVM.js
+++ b/public/js/globalVM.js
@@ -1,6 +1,8 @@
 /**
- * globalVM
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['jquery', 'Browser', 'Utils', 'underscore', 'Params', 'intl', 'i18n', 'knockout', 'lib/PubSub', 'moment'], function ($, Browser, Utils, _, P, intl, i18n, ko, ps, moment) {
     'use strict';
 

--- a/public/js/i18n.js
+++ b/public/js/i18n.js
@@ -1,6 +1,8 @@
 /**
- * Localizations
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['knockout', 'knockout.mapping'], function (ko, koMapping) {
     'use strict';
 

--- a/public/js/intl/intl.js
+++ b/public/js/intl/intl.js
@@ -1,6 +1,8 @@
 /**
- * Internationalisation functions
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['Utils'], function () {
     'use strict';
 

--- a/public/js/lib/Browser.js
+++ b/public/js/lib/Browser.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Browser Detect
  *
  * @author Klimashkin P.

--- a/public/js/lib/JSExtensions.js
+++ b/public/js/lib/JSExtensions.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 if (!String.prototype.includes) {
     // eslint-disable-next-line no-extend-native
     String.prototype.includes = function () {

--- a/public/js/lib/Utils.js
+++ b/public/js/lib/Utils.js
@@ -1,7 +1,12 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Utils
  *
- * @author Klimashkin P.
+ * @author Klimashkin
  */
 define(['jquery', 'underscore', 'underscore.string', 'lib/jsuri', 'lib/jquery/plugins/extends'], function ($, _, _s) {
     const Utils = {

--- a/public/js/lib/knockout/extends.js
+++ b/public/js/lib/knockout/extends.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * @author Klimashkin
  */
 define(['jquery', 'underscore', 'knockout'], function ($, _, ko) {

--- a/public/js/lib/leaflet/extends/L.Google.js
+++ b/public/js/lib/leaflet/extends/L.Google.js
@@ -1,6 +1,9 @@
-/*
- * Google layer plugin wrapper. Loads Google Maps library with API key included.
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
+// Google layer plugin wrapper. Loads Google Maps library with API key included.
 define(['Params', 'leaflet', 'leaflet-plugins/lru', 'leaflet-plugins/Leaflet.GoogleMutant'], function (P, L) {
     const keyParam = P.settings.publicApiKeys.googleMaps.length ? '&key=' + P.settings.publicApiKeys.googleMaps : '';
     const url = 'https://maps.googleapis.com/maps/api/js?v=weekly&region=RU' + keyParam;

--- a/public/js/lib/leaflet/extends/L.Yandex.js
+++ b/public/js/lib/leaflet/extends/L.Yandex.js
@@ -1,4 +1,10 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /* global ymaps */
+
 /*
  * Yandex layer plugin wrapper. Loads Yandex maps library with API key included.
  * Requires L.Yandex ^3.3.2 (https://github.com/shramov/leaflet-plugins/).

--- a/public/js/lib/leaflet/extends/L.neoMap.js
+++ b/public/js/lib/leaflet/extends/L.neoMap.js
@@ -1,6 +1,9 @@
-/*
- * Map helper.
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
+// Map helper.
 define(['jquery', 'Utils', 'leaflet', 'Params'], function ($, Utils, L, P) {
     'use strict';
 

--- a/public/js/model/Photo.js
+++ b/public/js/model/Photo.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['jquery', 'underscore', 'knockout', 'knockout.mapping', 'Utils', 'model/User', 'model/Region', 'm/photo/status'],
     function ($, _, ko, koMapping, Utils, User, Region, statuses) {
         'use strict';

--- a/public/js/model/Region.js
+++ b/public/js/model/Region.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['jquery', 'underscore', 'Utils', 'knockout', 'knockout.mapping'], function ($, _, Utils, ko, ko_mapping) {
     'use strict';
 

--- a/public/js/model/User.js
+++ b/public/js/model/User.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['jquery', 'underscore', 'Utils', 'knockout', 'knockout.mapping', 'Params', 'model/Region'], function ($, _, Utils, ko, ko_mapping, P, Region) {
     'use strict';
 

--- a/public/js/model/storage.js
+++ b/public/js/model/storage.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['jquery', 'underscore', 'knockout', 'knockout.mapping', 'Utils', 'socket!', 'globalVM', 'model/User', 'model/Photo', 'noties'], function ($, _, ko, ko_mapping, Utils, socket, globalVM, User, Photo, noties) {
     'use strict';
 

--- a/public/js/module/_moduleCliche.js
+++ b/public/js/module/_moduleCliche.js
@@ -1,6 +1,8 @@
 /**
- * Шаблон для модулей
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['jquery', 'Utils', 'underscore', 'knockout', 'globalVM', 'renderer'], function ($, Utils, _, ko, globalVM, renderer) {
     'use strict';
 

--- a/public/js/module/admin/conveyer.js
+++ b/public/js/module/admin/conveyer.js
@@ -1,6 +1,8 @@
 /**
- * Администрирование конвейера
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping',
     'm/_moduleCliche', 'globalVM', 'renderer', 'model/User', 'model/storage', 'noties',

--- a/public/js/module/admin/main.js
+++ b/public/js/module/admin/main.js
@@ -1,6 +1,8 @@
 /**
- * Модель главной в админке
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'renderer',
     'text!tpl/admin/main.pug', 'css!style/admin/main',

--- a/public/js/module/admin/menu.js
+++ b/public/js/module/admin/menu.js
@@ -1,6 +1,8 @@
 /**
- * Модель верхнего меню админки
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'text!tpl/admin/menu.pug', 'css!style/admin/menu'], function (_, ko, ko_mapping, Cliche, globalVM, pug) {
     'use strict';
 

--- a/public/js/module/admin/newsEdit.js
+++ b/public/js/module/admin/newsEdit.js
@@ -1,6 +1,8 @@
 /**
- * Модель создания/редактирования новости
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche',
     'globalVM', 'model/User', 'model/storage', 'noties', 'text!tpl/admin/newsEdit.pug', 'css!style/admin/newsEdit',

--- a/public/js/module/admin/region.js
+++ b/public/js/module/admin/region.js
@@ -1,6 +1,8 @@
 /**
- * Модель региона
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'leaflet', 'noties', 'm/photo/status', 'renderer',

--- a/public/js/module/admin/regionCheck.js
+++ b/public/js/module/admin/regionCheck.js
@@ -1,6 +1,9 @@
 /**
- * Модель проверки региона по координате
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
+// Module for checking region by geo coordianates.
 define([
     'underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'noties', 'leaflet', 'lib/doT',

--- a/public/js/module/admin/regionFeatureInsert.js
+++ b/public/js/module/admin/regionFeatureInsert.js
@@ -1,6 +1,8 @@
 /**
- * Модель вставки FeatureCollection
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'model/storage', 'noties', 'text!tpl/admin/regionFeatureInsert.pug', 'css!style/admin/regionFeatureInsert',

--- a/public/js/module/admin/regionList.js
+++ b/public/js/module/admin/regionList.js
@@ -1,6 +1,8 @@
 /**
- * Модель списка регионов
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM',
     'model/storage', 'noties', 'text!tpl/admin/regionList.pug', 'css!style/admin/regionList',

--- a/public/js/module/admin/submenu.js
+++ b/public/js/module/admin/submenu.js
@@ -1,6 +1,8 @@
 /**
- * Модель левого подменю админки
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'knockout', 'm/_moduleCliche', 'globalVM', 'text!tpl/admin/submenu.pug', 'css!style/admin/submenu'], function (_, ko, Cliche, globalVM, pug) {
     'use strict';
 

--- a/public/js/module/appAdmin.js
+++ b/public/js/module/appAdmin.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 require([
     'domReady!',
     'jquery',

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 require([
     'domReady!', 'jquery', 'Browser', 'Utils', 'socket!', 'underscore', 'knockout', 'moment',
     'globalVM', 'Params', 'renderer', 'router', 'model/Photo', 'model/User', 'noties',

--- a/public/js/module/comment/comments.js
+++ b/public/js/module/comment/comments.js
@@ -1,6 +1,8 @@
 /**
- * Модель комментариев к объекту
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'underscore.string', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping',
     'noties', 'm/_moduleCliche', 'globalVM', 'renderer', 'moment', 'lib/doT', 'text!tpl/comment/comments.pug',

--- a/public/js/module/comment/hist.js
+++ b/public/js/module/comment/hist.js
@@ -1,6 +1,8 @@
 /**
- * Модель истории комментария
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/storage', 'lib/doT', 'text!tpl/comment/hist.pug', 'css!style/comment/hist'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, storage, doT, pug) {
     'use strict';
 

--- a/public/js/module/common/auth.js
+++ b/public/js/module/common/auth.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /*global init:true */
 define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'model/storage', 'model/User', 'text!tpl/common/auth.pug', 'css!style/common/auth'], function (_, $, Utils, socket, P, ko, Cliche, globalVM, storage, User, pug) {
     'use strict';

--- a/public/js/module/common/dummy.js
+++ b/public/js/module/common/dummy.js
@@ -1,6 +1,8 @@
 /**
- * Заглушка
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['jquery', 'Utils', 'Params', 'globalVM', 'knockout', 'm/_moduleCliche', 'text!tpl/dummy.pug', 'css!style/dummy'], function ($, Utils, P, globalVM, ko, Cliche, pug) {
     return Cliche.extend({
         pug: pug,

--- a/public/js/module/common/foot.js
+++ b/public/js/module/common/foot.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['underscore', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'renderer', 'text!tpl/common/foot.pug', 'css!style/common/foot'], function (_, P, ko, Cliche, globalVM, renderer, pug) {
     'use strict';
 

--- a/public/js/module/common/reason.js
+++ b/public/js/module/common/reason.js
@@ -1,6 +1,8 @@
 /**
- * Выбор причины
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'globalVM', 'knockout', 'm/_moduleCliche', 'text!tpl/common/reason.pug', 'css!style/common/reason'], function (_, $, Utils, socket, P, globalVM, ko, Cliche, pug) {
     'use strict';
 

--- a/public/js/module/common/share.js
+++ b/public/js/module/common/share.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+/**
  * Share dialog for social networks
  */
 define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'globalVM', 'knockout', 'm/_moduleCliche', 'text!tpl/common/share.pug', 'css!style/common/share'], function (_, $, Utils, socket, P, globalVM, ko, Cliche, pug) {

--- a/public/js/module/common/top.js
+++ b/public/js/module/common/top.js
@@ -1,6 +1,8 @@
 /**
- * Модель управляет верхней панелью
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Params', 'socket!', 'jquery', 'knockout', 'm/_moduleCliche', 'globalVM', 'text!tpl/common/top.pug', 'css!style/common/top', 'm/common/auth'], function (_, P, socket, $, ko, Cliche, globalVM, pug) {
     'use strict';
 

--- a/public/js/module/diff/about.js
+++ b/public/js/module/diff/about.js
@@ -1,6 +1,8 @@
 /**
- * Модель О проекте
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Params', 'socket!', 'knockout', 'm/_moduleCliche', 'globalVM', 'text!tpl/diff/about.pug', 'css!style/diff/about'], function (_, P, socket, ko, Cliche, globalVM, pug) {
     'use strict';
 

--- a/public/js/module/diff/news.js
+++ b/public/js/module/diff/news.js
@@ -1,6 +1,8 @@
 /**
- * Модель новости
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'renderer', 'moment', 'model/Photo', 'model/storage', 'text!tpl/diff/news.pug', 'css!style/diff/news'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, renderer, moment, Photo, storage, pug) {
     'use strict';
 

--- a/public/js/module/diff/newsList.js
+++ b/public/js/module/diff/newsList.js
@@ -1,6 +1,8 @@
 /**
- * Модель Списка новостей
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'model/User', 'model/storage',

--- a/public/js/module/main/bottomPanel.js
+++ b/public/js/module/main/bottomPanel.js
@@ -1,6 +1,8 @@
 /**
- * Модель нижней панели на главной
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/Photo', 'model/User', 'model/storage', 'm/photo/status', 'text!tpl/main/bottomPanel.pug', 'css!style/main/bottomPanel'], function (_, Browser, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, Photo, User, storage, statuses, pug) {
     'use strict';
 

--- a/public/js/module/main/commentsFeed.js
+++ b/public/js/module/main/commentsFeed.js
@@ -1,6 +1,8 @@
 /**
- * Модель ленты последних комментариев
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'model/Photo', 'lib/doT', 'text!tpl/main/commentsFeed.pug', 'css!style/main/commentsFeed',

--- a/public/js/module/main/mainPage.js
+++ b/public/js/module/main/mainPage.js
@@ -1,6 +1,8 @@
 /**
- * Модель содержимого основной страницы
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/Photo', 'text!tpl/main/mainPage.pug', 'css!style/main/mainPage'], function (_, Utils, P, ko, ko_mapping, Cliche, globalVM, Photo, pug) {
     'use strict';
 

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -1,6 +1,8 @@
 /**
- * Модель карты
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Browser', 'Utils', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'renderer',
     'model/User', 'model/storage', 'Locations', 'leaflet', 'leaflet-extends/L.neoMap', 'm/map/marker',

--- a/public/js/module/map/mapClusterCalc.js
+++ b/public/js/module/map/mapClusterCalc.js
@@ -1,6 +1,8 @@
 /**
- * Модель карты
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM',
     'renderer', 'model/User', 'model/storage', 'leaflet', 'leaflet-extends/L.neoMap', 'noties',

--- a/public/js/module/map/marker.js
+++ b/public/js/module/map/marker.js
@@ -1,6 +1,8 @@
 /**
- * Класс управления маркерами
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'globalVM', 'leaflet', 'model/Photo', 'turf',
 ], function (_, Utils, socket, P, ko, ko_mapping, globalVM, L, Photo, turf) {

--- a/public/js/module/map/navSlider.js
+++ b/public/js/module/map/navSlider.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define([
     'jquery', 'underscore', 'Browser', 'Utils', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'renderer',
     'leaflet', 'leaflet-extends/L.neoMap', 'Locations', '../../EventTypes',

--- a/public/js/module/photo/fields.js
+++ b/public/js/module/photo/fields.js
@@ -1,6 +1,8 @@
 /**
- * Модель статусов фотографии
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['m/photo/status'], function () {
     return {
         s: 'Статус',

--- a/public/js/module/photo/gallery.js
+++ b/public/js/module/photo/gallery.js
@@ -1,6 +1,8 @@
 /**
- * Модель галереи фотографий
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche',
     'globalVM', 'renderer', 'model/Photo', 'model/storage', 'm/photo/status', 'lib/jsuri',

--- a/public/js/module/photo/hist.js
+++ b/public/js/module/photo/hist.js
@@ -1,6 +1,8 @@
 /**
- * Модель истории комментария
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(
     ['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/storage', 'm/photo/fields', 'm/photo/status', 'lib/doT', 'text!tpl/photo/hist.pug', 'css!style/photo/hist'],
     function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, storage, fields, statuses, doT, pug) {

--- a/public/js/module/photo/photo.js
+++ b/public/js/module/photo/photo.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /* global init:true */
 /**
  * Модель страницы фотографии

--- a/public/js/module/photo/status.js
+++ b/public/js/module/photo/status.js
@@ -1,6 +1,8 @@
 /**
- * Модель статусов фотографии
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore'], function (_) {
     'use strict';
 

--- a/public/js/module/region/select.js
+++ b/public/js/module/region/select.js
@@ -1,6 +1,8 @@
 /**
- * Модель выбора регионов
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'model/storage', 'noties', 'text!tpl/region/select.pug', 'css!style/region/select', 'bs/ext/tokenfield',

--- a/public/js/module/user/brief.js
+++ b/public/js/module/user/brief.js
@@ -1,6 +1,8 @@
 /**
- * Модель статистики пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Params', 'knockout', 'socket!', 'm/_moduleCliche', 'globalVM', 'model/storage', 'model/User',
     'noties', 'text!tpl/user/brief.pug', 'css!style/user/brief',

--- a/public/js/module/user/comments.js
+++ b/public/js/module/user/comments.js
@@ -1,6 +1,8 @@
 /**
- * Модель списка комментариев пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'renderer', 'model/Photo', 'model/storage', 'text!tpl/user/comments.pug', 'css!style/user/comments'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, renderer, Photo, storage, pug) {
     'use strict';
 

--- a/public/js/module/user/manage.js
+++ b/public/js/module/user/manage.js
@@ -1,6 +1,8 @@
 /**
- * Модель управления пользователем
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Utils', 'socket!', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'noties',
     'renderer', 'model/User', 'model/storage', 'text!tpl/user/manage.pug', 'css!style/user/manage', 'bs/collapse',

--- a/public/js/module/user/photoUpload.js
+++ b/public/js/module/user/photoUpload.js
@@ -1,6 +1,8 @@
 /**
- * Модель загрузки фотографии
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/storage', 'load-image', 'text!tpl/user/photoUpload.pug', 'css!style/user/photoUpload', 'jfileupload/jquery.iframe-transport', 'jfileupload/jquery.fileupload'], function (_, Browser, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, storage, loadImage, pug) {
     'use strict';
 

--- a/public/js/module/user/profile.js
+++ b/public/js/module/user/profile.js
@@ -1,6 +1,8 @@
 /**
- * Модель профиля пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/User', 'model/storage', 'moment', 'text!tpl/user/profile.pug', 'css!style/user/profile'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, User, storage, moment, pug) {
     'use strict';
 

--- a/public/js/module/user/session.js
+++ b/public/js/module/user/session.js
@@ -1,6 +1,8 @@
 /**
- * Модель просмотра сессии
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/storage', 'lib/doT', 'text!tpl/user/session.pug', 'css!style/user/session'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, storage, doT, pug) {
     'use strict';
 

--- a/public/js/module/user/sessions.js
+++ b/public/js/module/user/sessions.js
@@ -1,6 +1,8 @@
 /**
- * Модель просмотра сессий пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'renderer', 'noties', 'model/User', 'model/storage',

--- a/public/js/module/user/settings.js
+++ b/public/js/module/user/settings.js
@@ -1,6 +1,8 @@
 /**
- * Модель настроек пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define([
     'underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM',
     'renderer', 'noties', 'm/photo/fields', 'model/Region', 'model/User', 'model/storage',

--- a/public/js/module/user/subscr.js
+++ b/public/js/module/user/subscr.js
@@ -1,6 +1,8 @@
 /**
- * Модель подписок пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/Photo', 'model/storage', 'moment', 'text!tpl/user/subscr.pug', 'css!style/user/subscr'], function (_, Utils, socket, P, ko, ko_mapping, Cliche, globalVM, Photo, storage, moment, pug) {
     'use strict';
 

--- a/public/js/module/user/userPage.js
+++ b/public/js/module/user/userPage.js
@@ -1,6 +1,8 @@
 /**
- * Модель содержимого страницы пользователя
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['underscore', 'Utils', 'Params', 'renderer', 'knockout', 'knockout.mapping', 'm/_moduleCliche', 'globalVM', 'model/storage', 'model/User', 'text!tpl/user/userPage.pug', 'css!style/user/userPage', 'bs/affix'], function (_, Utils, P, renderer, ko, ko_mapping, Cliche, globalVM, storage, User, pug) {
     'use strict';
 

--- a/public/js/noties.js
+++ b/public/js/noties.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['underscore', 'jquery', 'Utils'], function (_, $, Utils) {
     'use strict';
 

--- a/public/js/renderer.js
+++ b/public/js/renderer.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define([
     'jquery', 'Utils', 'underscore', 'knockout', 'globalVM', 'lib/doT', 'text!tpl/modal.pug',
 ], function ($, Utils, _, ko, globalVM, doT, dotModal) {

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -1,6 +1,8 @@
 /**
- * Менеджер путей
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
+
 define(['jquery', 'underscore', 'Utils', 'knockout', 'globalVM', 'renderer'], function ($, _, Utils, ko, globalVM, renderer) {
     'use strict';
 

--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 define(['module'], function (/* module */) {
     'use strict';
 

--- a/sitemap.js
+++ b/sitemap.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import fs from 'fs';
 import _ from 'lodash';
 import path from 'path';

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { MongoMemoryServer } from 'mongodb-memory-server';
 
 // Substitute alternate configuration.

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 export default async function () {
     // Stop mongodb-memory-server.
     const instance = global.__MONGOMSINSTANCE__; // eslint-disable-line no-underscore-dangle

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 /* eslint-env jest */
 import connectDb, { waitDb } from '../controllers/connection';
 import mongoose from 'mongoose';

--- a/tests/test.config.js
+++ b/tests/test.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 // This configuration has the same purpose as local.config.js in normal run,
 // but applied in test environment.
 module.exports = function (config, appRequire) {

--- a/tests/testHelpers.js
+++ b/tests/testHelpers.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import { User, UserConfirm } from '../models/User';
 import auth from '../controllers/auth';
 

--- a/uploader.js
+++ b/uploader.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import fs, { promises as fsAsync } from 'fs';
 import gm from 'gm';
 import mv from 'mv';

--- a/worker.js
+++ b/worker.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
 import ms from 'ms';
 import moment from 'moment';
 import log4js from 'log4js';


### PR DESCRIPTION
Following the discussion at #448 it has been agreed to use GNU AGPLv3+ for the PastVu app code.

I suggest to use simplified copyright and license declaration in the files. 
```
/**
 * Copyright: Contributors to the PastVu project.
 * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
 */
```

Not having full GPL prefix in files does not violate license, as it permits to do so:
> ... and each file should have at least the "copyright" line and a pointer to where the full notice is found.

With regard to copyright, suggested form is recommended by Linux Foundation: https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects

There are projects that use similar approach for files licensing, [Ansible for example](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#copyright-and-license).

For now adding notice to eslint covered files only, some files are probably omited, but this will be adressed alongside upcoming changes on client side.

Please also approve changes in documentation: https://github.com/PastVu/docs/pull/7