### PR TITLE
Add /rules route redirect and make URL configurable.

### DIFF
--- a/config/default.config.js
+++ b/config/default.config.js
@@ -105,4 +105,8 @@ module.exports = {
     // Interval between sitemap complete regeneration. First run - next interval after last midnight
     sitemapInterval: ms('12h'),
     sitemapGenerateOnStart: false, // First run must be on server start
+
+    docs: {
+        rulesUrl: 'https://docs.pastvu.com/rules', // Rules document location.
+    },
 };

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -286,6 +286,12 @@ export function bindRoutes(app) {
         app.use('/api2', require('body-parser').json({ limit: '4mb' }), handleHTTPRequest, handleHTTPAPIRequest);
     }
 
+    // Rules
+    app.get('/rules', (req, res) => {
+        // This used to be a modal popup, we have to keep redirect to documentation page.
+        res.redirect(301, config.docs.rulesUrl);
+    });
+
     // Admin section
     app.get(/^\/(?:admin)(?:\/.*)?$/, handleHTTPRequest, setStaticHeaders, appAdminHandler);
 

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -21,9 +21,9 @@ const getUserRanks = () => constants.user.ranks;
 // Fill object for client parameters
 async function fillClientParams() {
     const settings = await Settings.find({}, { _id: 0, key: 1, val: 1 }, { lean: true }).exec();
-    const { lang, hash, publicApiKeys, version } = config;
+    const { lang, hash, publicApiKeys, version, docs } = config;
 
-    Object.assign(clientParams, { lang, hash, publicApiKeys, version });
+    Object.assign(clientParams, { lang, hash, publicApiKeys, version, docs });
 
     for (const setting of settings) {
         clientParams[setting.key] = setting.val;

--- a/public/js/Params.js
+++ b/public/js/Params.js
@@ -37,7 +37,7 @@ define(['jquery', 'underscore', 'socket!', 'Utils', 'knockout', 'knockout.mappin
 
     // Create Params view model, define properties that will not be observable
     // when view model is converted to JS object.
-    Params = koMapping.fromJS(Params, { copy: ['window.head', 'settings.lang', 'settings.publicApiKeys'] });
+    Params = koMapping.fromJS(Params, { copy: ['window.head', 'settings.lang', 'settings.publicApiKeys', 'settings.docs'] });
 
     // Пересчитываем размеры при ресайзе окна
     $window.on('resize', _.debounce(function () {

--- a/public/js/module/common/foot.js
+++ b/public/js/module/common/foot.js
@@ -78,6 +78,9 @@ define(['underscore', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'rend
             } else {
                 globalVM.router.navigate('/');
             }
-        }
-	});
+        },
+        getRulesUrl: function () {
+            return P.settings.docs.rulesUrl;
+        },
+    });
 });

--- a/views/module/common/foot.pug
+++ b/views/module/common/foot.pug
@@ -2,7 +2,7 @@
     .rightSide.hide-text
         a.footElem.strokeAfter(href="mailto:support@pastvu.com", target="_blank", onclick="ga('send', 'event', 'support', 'click', 'support click common');")
             | Поддержка: support@pastvu.com
-        a.footElem.strokeAfter(href="https://docs.pastvu.com/rules", target="_blank", onclick="ga('send', 'event', 'rules', 'click', 'rules click common');")
+        a.footElem.strokeAfter(data-bind="attr: {href: getRulesUrl()}", target="_blank", onclick="ga('send', 'event', 'rules', 'click', 'rules click common');")
             | Правила
         .footElem.strokeAfter(data-bind="click: navigateAbout") О проекте
         a.footElem.strokeAfter(href="https://github.com/PastVu", target="_blank", onclick="ga('send', 'event', 'github', 'click', 'go to github');")


### PR DESCRIPTION
There is a number of user comments that refer to `/rules` route, this should keep working following #499 landing which removed the route.

Also this patch makes rules URL stored in default config rather than being hardcoded. This would make it easier to change in case of change to different location.