### PR TITLE
github: Do not run automerge and image build on forks.

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,8 +14,9 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-
   build-and-push-app:
+    # This only makes sense to run for pastvu owned repo.
+    if: github.repository_owner == 'pastvu'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Added for image also (discussed with @aeifn), it runs on forks as sheduled task. If image creation debugging is needed, it would be easier just to comment this line in the local branch.