### PR TITLE
Fix year sliders issues when both sliders are set to the same year

### DIFF
--- a/public/js/lib/jquery/ui/PASTVU-CHANGES
+++ b/public/js/lib/jquery/ui/PASTVU-CHANGES
@@ -1,0 +1,12 @@
+=== jquery-ui ===
+
+jQuery user interface library is deployed manually from its repo https://github.com/jquery/jquery-ui.
+
+Theme (Smoothness) files are located at public/style/jquery/ui/ and public/img/jqueryui/
+
+=== Local changes to jquery-ui ===
+
+08/12/22
+
+Added patch to fix slider widget issues when both sliders are set to the same
+year. See #532 for details.


### PR DESCRIPTION
This patch addresses #532 

- Fixes sliders "stick together" issue when user is moving the slider
  located opposite to the one moved last.
- Fixes shifting of sliders by clicking on scale outside sliders.

The fix idea is taken from PR https://github.com/jquery/jquery-ui/pull/1514
(which has not been merged to jquery-ui) and elaborated (may be I should submit fix upstream as latest version still has this problem).

The purpose of PASTVU-CHANGES file is for someone to spot local modification when upgrading the library.