### PR TITLE
Maps zooms review and improvements

### DIFF
--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -172,9 +172,10 @@ define([
                         obj: new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                             attribution: '&copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                             updateWhenIdle: false,
-                            maxZoom: 19,
+                            maxZoom: 20,
+                            maxNativeZoom: 19,
                         }),
-                        maxZoom: 19,
+                        maxZoom: 20,
                     },
                     {
                         id: 'mapnik_de',
@@ -225,11 +226,12 @@ define([
                         obj: new L.TileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.{ext}', {
                             attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> | &copy; участники сообщества <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                             subdomains: 'abcd',
-                            maxZoom: 20,
+                            maxZoom: 19,
+                            maxNativeZoom: 18,
                             ext: 'png',
                             updateWhenIdle: false,
                         }),
-                        maxZoom: 20,
+                        maxZoom: 19,
                     },
                 ]),
             });
@@ -285,7 +287,7 @@ define([
                             desc: 'Схема',
                             selected: ko.observable(false),
                             params: 'map',
-                            maxZoom: 20,
+                            maxZoom: 21,
                         },
                         {
                             id: 'sat',

--- a/public/js/module/map/navSlider.js
+++ b/public/js/module/map/navSlider.js
@@ -13,6 +13,7 @@ define([
     return Cliche.extend({
         pug: pug,
         options: {
+            minZoom: 3,
             maxZoom: 18,
             canOpen: true,
         },
@@ -27,7 +28,7 @@ define([
             this.sliding = ko.observable(false);
 
             this.step = ko.observable(9);
-            this.minZoom = ko.observable(0);
+            this.minZoom = ko.observable(this.options.minZoom);
             this.maxZoom = ko.observable(this.options.maxZoom);
             this.numZooms = ko.observable(false);
             this.sliderOnZoom = ko.observable(this.map.getZoom());


### PR DESCRIPTION
* Review map zooms, change maxZoom for maps that support higher resolution. Set "overzoom" to 20 on Mapnik.
* Remove excessive `maxZoom` property from layer type object - This will make map definition less confusing. We normally have `maxZoom` defined in TileLayer object anyway, there is no need to duplicate same value in map type object.