### PR TITLE
en: Fix plural form for user stats text.

### DIFF
--- a/public/js/module/main/bottomPanel.js
+++ b/public/js/module/main/bottomPanel.js
@@ -294,7 +294,7 @@ define(['underscore', 'Browser', 'Utils', 'socket!', 'Params', 'knockout', 'knoc
                     self.stats.all = data.all;
                     self.stats.common = data.common;
                     self.stats.common.onlineTxt = 'Now ' + globalVM.intl.num(data.common.onall) +
-                        declension.user + (data.common.onall > 1 ? 's' : '') + ' is online, ' +
+                        declension.user[0] + (data.common.onall > 1 ? 's are' : ' is') + ' online, ' +
                         data.common.onreg + ' of them are registered';
                     success = true;
                 }


### PR DESCRIPTION
Fixes #317

![image](https://user-images.githubusercontent.com/329780/210540134-f48b2e05-52be-4bc6-a793-68def515b05a.png)

![image](https://user-images.githubusercontent.com/329780/210540065-5ec1ecc9-b026-41d4-99c8-0a36d1a04009.png)

This would need to be refactored one day to produce plural form strings via language tool.