### PR TITLE
URL parsing fixes

### DIFF
--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -313,9 +313,10 @@ Utils.linkifyUrlString = function (text, target, className) {
         }
 
         try {
-            // Decode URI, e.g. to make http://ru.wikipedia.org/wiki/%D0%A1%D0%B5%D0%BA%D1%81 url readable.
-            url = decodeURI(url);
-            linkText = decodeURI(linkText);
+            // Decode URI, e.g. to make http://ru.wikipedia.org/wiki/%D0%A1%D0%B5%D0%BA%D1%81 url readable,
+            // then replace spaces with + sign, so we won't loose part of URL on consequent editing.
+            url = decodeURI(url).replace(/\s+/g, '+');
+            linkText = decodeURI(linkText).replace(/\s+/g, '+');
 
             return `<a href="${url}" rel="nofollow noopener"${target}${className}>${linkText}</a>${append}`;
         } catch (err) {

--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -356,7 +356,7 @@ Utils.inputIncomingParse = (function () {
 
         //Все внутрипортальные ссылки оставляем без доменного имени, от корня
         //Например, http://domain.com/u/klimashkin/photo -> /u/klimashkin/photo
-        result = result.replace(new RegExp(`(\\b)(?:https?://)?(?:www.)?${host}(/[-A-Z0-9+&@#\\/%?=~_|!:,.;]*[-A-Z0-9+&@#\\/%=~_|])`, 'gim'), '$1$2');
+        result = result.replace(new RegExp(`(\\b)(?:https?://)?(?<=[^.|www.])${host}(/[-A-Z0-9+&@#\\/%?=~_|!:,.;]*[-A-Z0-9+&@#\\/%=~_|])`, 'gim'), '$1$2');
 
         // Replace links to protected/covered photos with regular link
         // For example, /_pr/a/b/c/abc.jpg -> /_p/a/b/c/abc.jpg

--- a/commons/__tests__/Utils.test.js
+++ b/commons/__tests__/Utils.test.js
@@ -43,6 +43,7 @@ describe('utils', () => {
                 ['replace photo path', '/p/123456', '<a target="_blank" class="sharpPhoto" href="/p/123456">#123456</a>'],
                 ['replace photo hash', '#123456', '<a target="_blank" class="sharpPhoto" href="/p/123456">#123456</a>'],
                 ['replace encoded url', 'https://ru.wikipedia.org/wiki/%D0%A4%D0%BE%D1%82%D0%BE%D0%B3%D1%80%D0%B0%D1%84%D0%B8%D1%8F', '<a href="https://ru.wikipedia.org/wiki/Фотография" rel="nofollow noopener" target="_blank">https://ru.wikipedia.org/wiki/Фотография</a>'],
+                ['replace encoded url with space', 'https://forum.vgd.ru/post/14/127242/p4009576.htm?hlt=%D0%BD%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0%D0%B5%D0%B2%D1%81%D0%BA%D0%B0%D1%8F+%D1%81%D0%BB%D0%BE%D0%B1#pp4009576', '<a href="https://forum.vgd.ru/post/14/127242/p4009576.htm?hlt=николаевская+слоб#pp4009576" rel="nofollow noopener" target="_blank">https://forum.vgd.ru/post/14/127242/p4009576.htm?hlt=николаевская+слоб#pp4009576</a>'],
                 ['shorten internal url', `${origin}/u/klimashkin/photo`, '<a target="_blank" class="innerLink" href="/u/klimashkin/photo">/u/klimashkin/photo</a>'],
                 ['replace internal path', '/u/klimashkin/photo', '<a target="_blank" class="innerLink" href="/u/klimashkin/photo">/u/klimashkin/photo</a>'],
                 ['replace protected photo url', `${origin}/_pr/a/b/c/abc.jpg`, '<a target="_blank" class="innerLink" href="/_p/a/b/c/abc.jpg">/_p/a/b/c/abc.jpg</a>'],

--- a/commons/__tests__/Utils.test.js
+++ b/commons/__tests__/Utils.test.js
@@ -7,6 +7,7 @@ import Utils from '../Utils';
 import config from '../../config';
 
 const origin = config.client.origin;
+const host = config.client.host;
 
 /**
  * Test Utils.inputIncomingParse output matches expected.
@@ -67,6 +68,7 @@ describe('utils', () => {
                 ['replace url', 'https://jestjs.io/docs/expect#expectassertionsnumber', '<a href="https://jestjs.io/docs/expect#expectassertionsnumber" rel="nofollow noopener" target="_blank">https://jestjs.io/docs/expect#expectassertionsnumber</a>'],
                 ['replace www url', 'www.moodle.org', '<a href="http://www.moodle.org" rel="nofollow noopener" target="_blank">www.moodle.org</a>'],
                 ['replace url with params', 'https://jestjs.io/docs/expect?show=all&filter=1', '<a href="https://jestjs.io/docs/expect?show=all&filter=1" rel="nofollow noopener" target="_blank">https://jestjs.io/docs/expect?show=all&filter=1</a>'],
+                ['replace subdomain url', `https://docs.${host}/rules`, `<a href="https://docs.${host}/rules" rel="nofollow noopener" target="_blank">https://docs.${host}/rules</a>`],
             ];
 
             it.each(testData)('%s', testInputIncomingParse); // eslint-disable-line jest/expect-expect

--- a/tests/test.config.js
+++ b/tests/test.config.js
@@ -10,6 +10,9 @@ module.exports = function (config, appRequire) {
 
     _.merge(config, {
         env: 'test',
+        client: {
+            hostname: 'test.local',
+        },
         // It is important to flag instance as primary to avoid starting
         // region cache timer, which will prevent Jest from completing.
         primary: true,


### PR DESCRIPTION
This patch fixes issue when URL containing subdomain becomes shortened incorrectly like `https://docs./rules` #559 

Also this contains patch to addess the case when encoded URL contains spaces, once saved and edited again, this results in split URL.

Tests for both scenarions are included. 