### PR TITLE
Show text block when photo coordinates are not set.

### DIFF
--- a/public/style/map/map.less
+++ b/public/style/map/map.less
@@ -109,6 +109,15 @@
         height: 25px;
         margin-left: 3px;
         vertical-align: top;
+
+        &.warn {
+            background-color: #ffd62d;
+            padding: 3px 8px;
+            border-radius: 1px;
+            text-align: center;
+            height: 27px;
+            line-height: 1.7;
+        }
     }
 
     .button {
@@ -142,7 +151,7 @@
 
     .geoInput {
         height: 27px;
-        line-height: 26px;
+        line-height: 27px;
         white-space: nowrap;
 
         > input {

--- a/views/module/map/map.pug
+++ b/views/module/map/map.pug
@@ -15,6 +15,11 @@
                     |  Обнулить координаты
                 // /ko
             // /ko
+            //ko if: !editing() && !point.geo()
+            .mapInfo.warn
+                span.glyphicon.glyphicon-warning-sign
+                |  Координаты фотографии не указаны
+            // /ko
         // /ko
 
         .mapYearSelector


### PR DESCRIPTION
This patch brings back the text block (removed at #563) informing user that photo coordinate is not set:

![image](https://user-images.githubusercontent.com/329780/217841305-2db08767-6fe3-4fd1-a770-0c7b311f41d1.png)
