### PR TITLE
socket: Remove compatibility flag on server as clients were upgraded.

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,7 +210,6 @@ export async function configure(startStamp) {
 
     const httpServer = http.createServer(app);
     const io = new Server(httpServer, {
-        allowEIO3: true, // false by default, remove when client is updated from version 2.
         maxHttpBufferSize: 1e7, // Set buffer size to 10Mb handle large packets (e.g. region geometry)
         transports: ['websocket', 'polling'],
         path: '/socket.io',


### PR DESCRIPTION
We had to revert this patch in bc78d6df due to CDN cache was sending previous version socket client. Now it is safe to remove the flag completely.