### PR TITLE
Fix RangeError on photos map load.

### DIFF
--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -36,7 +36,7 @@ define([
 
             this.destroy = _.wrap(this.destroy, this.localDestroy);
 
-            // Promise witch will be resolved when map ready
+            // Promise which will be resolved when map ready
             this.readyPromise = new Promise(function (resolve) {
                 self.readyPromiseResolve = resolve;
             });
@@ -555,8 +555,13 @@ define([
                         callback: function (vm) {
                             this.childModules[vm.id] = vm;
                             this.navSliderVM = vm;
-                            // When slider is ready, update its limits.
-                            this.navSliderVM.recalcZooms(type.limitZoom || this.map.getMaxZoom(), true);
+
+                            // When slider is ready, update its limits (if
+                            // layer is loaded already, if not selectLayer
+                            // will update them).
+                            if (this.map.getMaxZoom() !== Infinity) {
+                                this.navSliderVM.recalcZooms(this.map.getMaxZoom(), true);
+                            }
                         }.bind(this),
                     },
                 ],
@@ -959,7 +964,6 @@ define([
                     type.options = type.options || {};
                     type.obj = new Construct(type.options);
                     setLayer(type);
-                    type = null;
                 });
             } else if (type.options.urlTemplate !== undefined) {
                 // Layer needs to be created using L.TileLayer.


### PR DESCRIPTION
Fixes 
![image](https://user-images.githubusercontent.com/329780/218889500-7ae9b68d-2903-40ce-ac4b-5ea36b88aca9.png)


The issue is caused by asyncronous nature of yandex and google maps loading. At the time when navigation bar is created, layer might be not loaded and maxZoom for the map is not set, thus map returns `Infinity`.

Ideally some control over sequence is needed, that may be addressed during refactoring, for now adding a quick fix.

I am not 100% sure this is a cause of #565 as I can't replicate it, but it might be.