### PR TITLE
Bugfix/restore ability to moderate disallowed comments

### DIFF
--- a/public/js/module/comment/comments.js
+++ b/public/js/module/comment/comments.js
@@ -793,7 +793,7 @@ define([
             }
         },
         edit: function (cid, $c) {
-            if (!this.canReply()) {
+            if (!this.canReply() && !this.canModerate()) {
                 return;
             }
 
@@ -1169,7 +1169,7 @@ define([
             }
         },
         send: function (vm, event) {
-            if (!vm.canReply()) {
+            if (!vm.canReply() && !vm.canModerate()) {
                 return;
             }
 

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -364,6 +364,10 @@ body {
     margin: 0 3px;
     font-family: Verdana, sans-serif;
     color: #888;
+
+    &:first-child {
+        display: none;
+    }
 }
 
 .margBott {

--- a/views/module/comment/cdotauth.pug
+++ b/views/module/comment/cdotauth.pug
@@ -26,16 +26,16 @@
             .changed(title="Показать историю изменений") {{='Изменен '+it.fDateIn(new Date(c.lastChanged))}}
             | {{?}}
         .ctext {{=c.txt}}
-        | {{?it.reply}}
         .cacts
+            | {{?it.reply}}
             span.cact.reply Ответить
-            | {{?it.mod || c.can.edit}}
+            | {{?}}
+            | {{?it.mod || (it.reply && c.can.edit)}}
             .dotDelimeter ·
             span.cact.edit Редактировать
             | {{?}}
-            | {{?it.mod || c.can.del}}
+            | {{?it.mod || (it.reply && c.can.del)}}
             .dotDelimeter ·
             span.cact.remove Удалить
             | {{?}}
-        | {{?}}
 | {{?}}


### PR DESCRIPTION
for user with moderator rights:
![localhost_3000_p_4 (2)](https://user-images.githubusercontent.com/6430448/219524243-9656b422-5e0e-4d70-b98f-d8318e2336cd.png)
![localhost_3000_p_4 (3)](https://user-images.githubusercontent.com/6430448/219524252-ebcc049f-15fa-4d7a-9ba0-3ec4983288f3.png)
then after page refresh
![localhost_3000_p_4 (4)](https://user-images.githubusercontent.com/6430448/219524260-60002336-895b-4a1d-92e5-507a152eba23.png)

for regular user:
![localhost_3000_p_4 (8)](https://user-images.githubusercontent.com/6430448/219525713-182e51ac-c0f0-4f1f-a3cc-466f12c8c44a.png)
![localhost_3000_p_4 (9)](https://user-images.githubusercontent.com/6430448/219525719-9a3e3b54-b0a3-432d-8393-1c6569bca787.png)

Resolves #137
(sorry for misspellings in admin john's comments)