### PR TITLE
Lift mapinfos block so it does not cover logos/copyrights

### DIFF
--- a/public/style/map/map.less
+++ b/public/style/map/map.less
@@ -99,7 +99,7 @@
         position: absolute;
         left: 5px;
         right: 5px;
-        bottom: 31px;
+        bottom: 52px;
         width: max-content;
     }
 


### PR DESCRIPTION
Style fix to lift copy coordinates button and interface to avoid obstucting map copyrights and logos (52px is doubled height of years slider, looks OK, but open to suggestions).

![image](https://user-images.githubusercontent.com/329780/220113711-cb2de47f-0e75-49b5-a654-d015dfbc87e3.png)

![image](https://user-images.githubusercontent.com/329780/220113847-90088fec-5e3f-40ac-b606-21ea7a151e43.png)
