### PR TITLE
Restore ability to select only public images in gallerie

### DIFF
--- a/public/js/module/photo/gallery.js
+++ b/public/js/module/photo/gallery.js
@@ -443,7 +443,7 @@ define([
                 filterString += (filterString ? '_' : '') + 'geo!' + geo[0];
             }
 
-            if (s.length && this.auth.iAm && !_.isEqual(s, [statuses.keys.PUBLIC])) {
+            if (s.length && this.auth.iAm) {
                 let allowedS;
 
                 if (this.auth.iAm.role() > 4 || this.itsMine()) {
@@ -604,7 +604,10 @@ define([
         filterSHandle: function (val) {
             if (_.isEmpty(val)) {
                 // If user removes last status checkbox, set public status as default
-                this.filter.disp.s([String(statuses.keys.PUBLIC)]);
+                // without timeout checkbox remains unchecked
+                setTimeout(function () {
+                    this.filter.disp.s([String(statuses.keys.PUBLIC)]);
+                }.bind(this), 10);
             } else {
                 this.filterChangeHandle();
             }


### PR DESCRIPTION
This way if no statuses are select, they will fallback to the server defined values (userGalleryBySelfDefaultStatuses, userGalleryByModeratorDefaultStatuses) #536


`http://localhost:3000/u/admin/photo?f=s!5`
![localhost_3000_u_admin_photo_f=s!5](https://user-images.githubusercontent.com/6430448/220705665-bd6b60fd-072b-4c1a-a843-086144e2e74b.png)

`http://localhost:3000/u/admin/photo`
![localhost_3000_u_admin_photo_f=s!5 (1)](https://user-images.githubusercontent.com/6430448/220705346-ea782879-329d-433d-bfcc-e4d61bb85195.png)

```
const userGalleryBySelfDefaultStatuses = [status.NEW, status.REVISION, status.READY, status.PUBLIC, status.DEACTIVATE];
const userGalleryByModeratorDefaultStatuses = [status.NEW, status.REVISION, status.READY, status.PUBLIC];
```

All the other filter behaviour stays the same (as far as I can see)