### PR TITLE
Use .tltp for map

### DIFF
--- a/public/js/lib/Utils.js
+++ b/public/js/lib/Utils.js
@@ -292,15 +292,18 @@ define(['jquery', 'underscore', 'underscore.string', 'lib/geocoordsparser', 'lib
         },
 
         flashTooltip: function (target, text) {
-            const element = $(target);
-            const origTitle = element.attr('title');
+            return new Promise(function (resolve) {
+                const element = $(target);
+                const origTitle = element.attr('title');
 
-            element.tooltip({ placement: 'right', trigger: 'manual' }).attr('data-original-title', text).tooltip('show');
-            setTimeout(function () {
-                element.tooltip('destroy');
-                // Restore original title as it seems being cleared.
-                element.attr('title', origTitle);
-            }, 1000);
+                element.tooltip({ placement: 'right', trigger: 'manual' }).attr('data-original-title', text).tooltip('show');
+                setTimeout(function () {
+                    element.tooltip('destroy');
+                    // Restore original title as it seems being cleared.
+                    element.attr('title', origTitle);
+                    resolve();
+                }, 1000);
+            });
         },
 
         popupCenter: function (url, title, w, h) {

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -6,7 +6,7 @@
 define([
     'underscore', 'Browser', 'Utils', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'renderer',
     'model/User', 'model/storage', 'Locations', 'leaflet', 'leaflet-extends/L.neoMap', 'm/map/marker',
-    'm/photo/status', 'text!tpl/map/map.pug', 'bs/tooltip', 'css!style/map/map', 'jquery-ui/draggable', 'jquery-ui/slider',
+    'm/photo/status', 'text!tpl/map/map.pug', 'css!style/map/map', 'jquery-ui/draggable', 'jquery-ui/slider',
     'jquery-ui/effect-highlight', 'css!style/jquery/ui/core', 'css!style/jquery/ui/theme', 'css!style/jquery/ui/slider',
     'css!style/jquery/ui/tooltip',
 ], function (_, Browser, Utils, P, ko, Cliche, globalVM, renderer, User, storage, Locations, L, Map, MarkerManager, statuses, pug) {
@@ -107,14 +107,6 @@ define([
                     },
                     owner: this,
                 });
-
-                this.geoInputComputed.subscribe(function (val) {
-                    const input = this.$dom.find('.geoInput input');
-
-                    if (input) {
-                        input.tooltip(_.isEmpty(val) ? 'show' : 'hide');
-                    }
-                }, this);
             }
 
             const type = this.type();
@@ -626,18 +618,6 @@ define([
         editPointOn: function () {
             this.editing(true);
 
-            // Add coordinates hint tooltip, always displayed when there are no coodinates.
-            let title = '<span class="material-icons-inline location-on"></span>&nbsp;';
-
-            title += 'Для установки координаты кликните по карте';
-
-            const input = $('.geoInput input').tooltip({ placement: 'right', trigger: 'manual', title: title, html: true });
-
-            if (!this.point.geo()) {
-                // Show it immediately if there are no coords.
-                input.tooltip('show');
-            }
-
             return this;
         },
         // Выключает режим редактирования
@@ -898,8 +878,13 @@ define([
         },
         copyGeo: function (data, evt) {
             if (this.point.geo()) {
+                // Temporaly hide custom tooltip so it does not overlap flashing one.
+                const tooltip = $(evt.currentTarget).siblings('.tltp').hide();
+
                 Utils.copyTextToClipboard(this.geoInputComputed());
-                Utils.flashTooltip(evt.currentTarget, 'Скопировано');
+                Utils.flashTooltip(evt.currentTarget, 'Скопировано').then(function () {
+                    tooltip.show();
+                });
             }
         },
         selectLayer: function (sysId, typeId) {

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -492,6 +492,7 @@ body {
     background: lighten(@MainDarkColor, 17%);
     border: 1px solid #7a7a7a;
     z-index: @zindex-tooltip;
+    text-align: center;
 
     /* This bridges the gap so you can mouse into the tooltip without it disappearing */
     &::before {
@@ -523,7 +524,6 @@ body {
     bottom: 100%;
     margin-bottom: 7px;
     padding: 3px 7px;
-    text-align: center;
     transform: translate(-50%, 0);
 
     &.tltp-animate-move {
@@ -582,7 +582,6 @@ body {
     right: 100%;
     margin-right: 5px;
     padding: 2px 5px;
-    text-align: right;
     transform: translate(0, -50%);
 
     &.tltp-animate-move {
@@ -612,7 +611,6 @@ body {
     top: 100%;
     margin-top: 7px;
     padding: 3px 7px;
-    text-align: center;
     transform: translate(-50%, 0);
 
     &.tltp-animate-move {

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -493,6 +493,7 @@ body {
     border: 1px solid #7a7a7a;
     z-index: @zindex-tooltip;
     text-align: center;
+    line-height: 1.5;
 
     /* This bridges the gap so you can mouse into the tooltip without it disappearing */
     &::before {
@@ -668,6 +669,10 @@ body {
             transform: translateX(-12px);
         }
     }
+}
+
+span.tltp-wrap {
+    display: inline-block;
 }
 
 .tltp-wrap {

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -673,6 +673,10 @@ body {
 .tltp-wrap {
     position: relative;
 
+    .tltp-show {
+        opacity: 1;
+    }
+
     &:hover {
         .tltp-touch {
             user-select: text;

--- a/public/style/common.less
+++ b/public/style/common.less
@@ -723,6 +723,14 @@ span.tltp-wrap {
     }
 }
 
+[aria-describedby]:hover {
+    position: relative;
+}
+
+[aria-describedby]:hover > [role='tooltip'] {
+    opacity: 1;
+}
+
 //Cтиль для подгрузки фото в контейнере с отображением ошибки
 .imgLoad {
     position: relative;

--- a/public/style/fonts/material-icons.less
+++ b/public/style/fonts/material-icons.less
@@ -57,7 +57,7 @@
     &:before {
         position: absolute;
         font-size: 1.2em;
-        top: 1px;
+        top: 0;
     }
 }
 

--- a/public/style/map/map.less
+++ b/public/style/map/map.less
@@ -703,14 +703,23 @@
         top: 5px;
         right: 5px;
         white-space: nowrap;
-    }
 
-    .trtool {
-        position: relative;
-        display: inline-block;
-        height: 25px;
-        margin-left: 3px;
-        vertical-align: top;
+        .tltp {
+            // Compensate space between buttons.
+            margin-left: 2px;
+
+            &.tltp-hotizontal-right {
+                right: -5px;
+            }
+        }
+
+        .trtool {
+            position: relative;
+            display: inline-block;
+            height: 25px;
+            margin-left: 3px;
+            vertical-align: top;
+        }
     }
 
     .fringe {

--- a/public/style/map/map.less
+++ b/public/style/map/map.less
@@ -101,23 +101,60 @@
         right: 5px;
         bottom: 52px;
         width: max-content;
-    }
 
-    .mapInfo {
-        text-align: center;
-        position: relative;
-        display: inline-block;
-        height: 25px;
-        margin-left: 3px;
-        vertical-align: top;
-
-        &.warn {
-            background-color: #ffd62d;
-            padding: 3px 8px;
-            border-radius: 1px;
+        .mapInfo {
             text-align: center;
+            position: relative;
+            display: inline-block;
+            height: 25px;
+            margin-left: 3px;
+            vertical-align: top;
+
+            &.warn {
+                background-color: #ffd62d;
+                padding: 3px 8px;
+                border-radius: 1px;
+                text-align: center;
+                height: 27px;
+                line-height: 1.7;
+            }
+        }
+
+        .geoInput {
             height: 27px;
-            line-height: 1.7;
+            line-height: 2;
+            white-space: nowrap;
+
+            > input {
+                height: 25px;
+                width: 157px;
+                color: #333;
+                text-align: center;
+                border: 1px solid @MainLigthColor;
+                background-color: @MainLigthColor;
+                .box-shadow(~'0 0 0 1px #000, 0 2px 4px 0px #222');
+
+                &:focus {
+                    outline: 0;
+                }
+            }
+
+            > button {
+                height: 25px;
+                margin-left: 4px;
+                line-height: 1.5;
+            }
+        }
+
+        .location-on::before {
+            font-family: 'Material Icons';
+            content: '\e0c8';
+        }
+
+        .location-off::before {
+            font-family: 'Material Icons';
+            content: '\e0c7';
+            top: 2px; // This one is shifted more than others.
         }
     }
 
@@ -147,43 +184,6 @@
 
         &.no .location-copy {
             content: url('@{iconLocationCopyI}');
-        }
-    }
-
-    .geoInput {
-        height: 27px;
-        line-height: 27px;
-        white-space: nowrap;
-
-        > input {
-            height: 25px;
-            width: 157px;
-            color: #333;
-            text-align: center;
-            border: 1px solid @MainLigthColor;
-            background-color: @MainLigthColor;
-            .box-shadow(~'0 0 0 1px #000, 0 2px 4px 0px #222');
-
-            &:focus {
-                outline: 0;
-            }
-        }
-
-        > button {
-            height: 25px;
-            margin-left: 4px;
-            line-height: 1.5;
-        }
-
-        .location-on::before {
-            font-family: 'Material Icons';
-            content: '\e0c8';
-        }
-
-        .location-off::before {
-            font-family: 'Material Icons';
-            content: '\e0c7';
-            top: 2px; // This one is shifted more than others.
         }
     }
 

--- a/views/module/map/map.pug
+++ b/views/module/map/map.pug
@@ -39,18 +39,29 @@
             .yearOuter.R
         .mapNavigation.mContainer.mHidden
         .trtools
-            .trtool.button.fringe(data-bind="css: {no: isPainting()}, click: function () {setPainting(false)}, attr: {title: 'Показывать на карте фотографии'}")
-                span.glyphicon.glyphicon-camera
-            .trtool.button.fringe(data-bind="css: {no: !isPainting()}, click: function () {setPainting(true)}, attr: {title: 'Показывать на карте картины/рисунки'}")
-                span.glyphicon.glyphicon-picture
-            .trtool.button.fringe(data-bind="css: {no: !openNewTab()}, click: function () {openNewTab(!openNewTab())}, attr: {title: (openNewTab() ? 'Выключить' : 'Включить') + ' открытие фотографий в новом окне'}")
-                span.glyphicon.glyphicon-share
+            span.tltp-wrap
+                .trtool.button.fringe(data-bind="css: {no: isPainting()}, click: function () {setPainting(false)}" aria-describedby="showphotosonmap")
+                    span.glyphicon.glyphicon-camera
+                .tltp.tltp-bottom.tltp-animate-opacity(id="showphotosonmap" role="tooltip")
+                    | Показывать на карте фотографии
+            span.tltp-wrap
+                .trtool.button.fringe(data-bind="css: {no: !isPainting()}, click: function () {setPainting(true)}" aria-describedby="showpaintingsonmap")
+                    span.glyphicon.glyphicon-picture
+                .tltp.tltp-bottom.tltp-animate-opacity(id="showpaintingsonmap" role="tooltip")
+                    | Показывать на карте картины/рисунки
+            span.tltp-wrap
+                .trtool.button.fringe(data-bind="css: {no: !openNewTab()}, click: function () {openNewTab(!openNewTab())}" aria-describedby="opennewtab")
+                    span.glyphicon.glyphicon-share
+                .tltp.tltp-bottom.tltp-hotizontal-right.tltp-animate-opacity(id="opennewtab" role="tooltip" data-bind="text: (openNewTab() ? 'Выключить' : 'Включить') + ' открытие фотографий в новом окне'")
             //ko if: !embedded
-            .trtool.button.link.fringe(data-bind="click: showLink", title="Ссылка на текущую позицию карты")
-                span.glyphicon.glyphicon-link
-                //ko if: linkShow()
-                input.inputLink(type="url", readonly, data-bind="click: linkClick, value: link()", autocorrect="off", autocapitalize="off")
-                // /ko
+            span.tltp-wrap
+                .trtool.button.link.fringe(data-bind="click: showLink", aria-describedby="showlink")
+                    span.glyphicon.glyphicon-link
+                    //ko if: linkShow()
+                    input.inputLink(type="url", readonly, data-bind="click: linkClick, value: link()", autocorrect="off", autocapitalize="off")
+                    // /ko
+                .tltp.tltp-bottom.tltp-hotizontal-right.tltp-animate-opacity(id="showlink" role="tooltip" data-bind="css: {hidden: linkShow()}")
+                    | Ссылка на текущую позицию карты
             // /ko
             .trtool.layersPanel.fringe(data-bind="css: {open: layersOpen()}")
                 .currentLayer(data-bind="click: toggleLayers, attr: {title: layersOpen() ? 'Нажмите, чтобы скрыть варианты' : 'Нажмите, чтобы увидеть доступные варианты карт'}")

--- a/views/module/map/map.pug
+++ b/views/module/map/map.pug
@@ -3,22 +3,31 @@
         .map
 
         //ko if: embedded
-        .mapInfos
-            .mapInfo.button.fringe(data-bind="css: {no: !point.geo()}, click: copyGeo, attr: {title: (point.geo() ? 'Скопировать координаты в буфер обмена' : 'Координаты фотографии не указаны')}")
+        .mapInfos.tltp-wrap
+            .mapInfo.button.fringe(data-bind="css: {no: !point.geo()}, click: copyGeo, attr: {'aria-label': (point.geo() ? 'Скопировать координаты в буфер обмена' : 'Координаты фотографии не указаны')}")
                 span.location-copy
+            //ko if: !editing() && point.geo()
+            .tltp.tltp-right.tltp-animate-opacity(style="white-space:nowrap")
+                | Скопировать координаты в буфер обмена
+            // /ko
             //ko if: editing()
             .mapInfo.geoInput
                 input(type="text", data-bind="value: geoInputComputed, valueUpdate: 'keyup', event: {focusout: geoInputBlur}", placeholder="Широта, долгота")
                 //ko if: point.geo()
                 button.btn.btn-warning(type="button", data-bind="click: delPointGeo")
                     span.material-icons-inline.location-off
-                    |  Обнулить координаты
+                    | &nbsp;Обнулить координаты
                 // /ko
+            // /ko
+            //ko if: editing() && !point.geo()
+            .tltp.tltp-right.tltp-show(style="white-space:nowrap")
+                span.material-icons-inline.location-on
+                | &nbsp;Для установки координаты кликните по карте
             // /ko
             //ko if: !editing() && !point.geo()
             .mapInfo.warn
                 span.glyphicon.glyphicon-warning-sign
-                |  Координаты фотографии не указаны
+                | &nbsp;Координаты фотографии не указаны
             // /ko
         // /ko
 

--- a/views/module/map/navSlider.pug
+++ b/views/module/map/navSlider.pug
@@ -9,8 +9,9 @@
                 span.glyphicon.glyphicon-arrow-down
             .mleft.fringe.butt(data-bind="event: {'click': function () { pan('left') }}")
                 span.glyphicon.glyphicon-arrow-left
-            .mhome.fringe.butt(data-bind="click: toHome, attr: {title: 'Установить карту в домашний регион ' + (auth.loggedIn() ? auth.iAm.regionHome.title_local() : 'Москва')}")
+            .mhome.fringe.butt(data-bind="click: toHome" aria-describedby="tohome")
                 span.glyphicon.glyphicon-home
+                .tltp.tltp-right.tltp-animate-opacity(style="white-space:nowrap" id="tohome" role="tooltip" data-bind="text: 'Установить карту в домашний регион ' + (auth.loggedIn() ? auth.iAm.regionHome.title_local() : 'Москва')")
             .zoomin.fringe.butt.inout(data-bind="event: {'click': function () { changeZoom(1) }}")
                 span.glyphicon.glyphicon-plus
             .zoomout.fringe.butt.inout(data-bind="event: {'click': function () { changeZoom(-1) }}")


### PR DESCRIPTION
For consistency, use existing CSS based tooltips for copy coordinates and geo input - visually it remains the same, just refactoring. We keep using BS tooltip for "flashing" info though (like "Copied" message popup).

This also replaces titles on other map buttons with tooltips (and hopefully makes it a little more accessible):
![image](https://user-images.githubusercontent.com/329780/221319072-acbf69d7-7260-45dd-b0f5-536c58d333d7.png)


