### PR TITLE
Add current location button to position map using geolocation.

### DIFF
--- a/public/style/map/map.less
+++ b/public/style/map/map.less
@@ -158,6 +158,21 @@
         }
     }
 
+    .mapPosTools {
+        position: absolute;
+        right: 5px;
+        bottom: 52px;
+        width: max-content;
+    }
+
+    .mapPosTool {
+        position: relative;
+        display: inline-block;
+        height: 25px;
+        margin-left: 3px;
+        vertical-align: top;
+    }
+
     .button {
         width: 26px;
         padding-top: 1px;
@@ -184,6 +199,18 @@
 
         &.no .location-copy {
             content: url('@{iconLocationCopyI}');
+        }
+
+        .my-location::before {
+            content: '\e55c';
+        }
+
+        &.nogeo .my-location::before {
+            content: '\e1b6';
+        }
+
+        &.pendinggeo .my-location::before {
+            content: '\e1b7';
         }
     }
 

--- a/views/module/map/map.pug
+++ b/views/module/map/map.pug
@@ -30,7 +30,12 @@
                 | &nbsp;Координаты фотографии не указаны
             // /ko
         // /ko
-
+        // ko if: isGeolocationSupported()
+        .mapPosTools.tltp-wrap
+                .mapPosTool.button.fringe(data-bind="click: showMyLocation, css: {no: geolocationStatus() === 'denied' || geolocationStatus() === 'error', nogeo: geolocationStatus() === 'denied', pendinggeo: geolocationStatus() === 'pending' }" aria-describedby="mylocation")
+                    span.material-icons.my-location
+                .tltp.tltp-left.tltp-animate-opacity(id="mylocation" role="tooltip" style="white-space:nowrap" data-bind="text: (geolocationStatus() === 'denied' ? 'Определение местоположения запрещено браузером' : geolocationStatus() === 'error' ? 'Не удается определить местоположение' : 'Моё местоположение')")
+        // /ko
         .mapYearSelector
             .yearSlider
                 .ui-slider-handle.L


### PR DESCRIPTION
The patch adds the new button that reposition the map to the current location (using geolocation data).

![image](https://user-images.githubusercontent.com/329780/221442819-c9983172-6ef6-43c6-aaf8-7aaef215a7e2.png)

If user denies using geolocation, button becomes inactive as:

![image](https://user-images.githubusercontent.com/329780/221442888-2c687945-b1c2-481b-9b1e-0738dbc04044.png)

Also there is an error state when location is not available for other reason (timeout or internal error):

![image](https://user-images.githubusercontent.com/329780/221443067-8cc66079-50d3-47fb-a236-dc068d1b5084.png)

Default zoom level on repositioning is 12. This is open to discussion, it is possible to keep current map zoom, but this may not be good idea at low zoom levels. May be we should use some logic, like for zooms > 12 keep current, but for others set to default 12.

Documentation page will follow (this needs to be explained to users, e.g. that we don't store location, how to enable, etc.)

