### PR TITLE
Show current conveyer queue size in the conveyer admin page.

### DIFF
--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -231,7 +231,7 @@ function fillImgPrior(parent, level) {
 }
 
 // Собираем статистику конвейера на начало каждой 10-минутки
-function collectConveyerStat() {
+async function collectConveyerStat() {
     const st = new STPhotoConveyer({
         stamp: new Date(+moment.utc().startOf('minute')),
         clength: conveyerMaxLength,
@@ -244,6 +244,8 @@ function collectConveyerStat() {
         }
     });
 
+    // Update stats.
+    conveyerLength = await PhotoConveyer.estimatedDocumentCount().exec();
     conveyerMaxLength = conveyerLength;
     conveyerConverted = 0;
     setTimeout(collectConveyerStat, ms('10m'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "PastVu",
-            "version": "2.0.15",
+            "version": "2.0.17",
             "dependencies": {
                 "@mapbox/geojson-area": "0.2.2",
                 "@mapbox/geojson-rewind": "0.5.0",

--- a/public/js/module/admin/conveyer.js
+++ b/public/js/module/admin/conveyer.js
@@ -485,7 +485,7 @@ define([
                         this.converted(data.conveyerConverted);
                     }
 
-                    this.timeoutUpdate = window.setTimeout(this.statFast.bind(this), 2000);
+                    this.timeoutUpdate = window.setTimeout(this.statFast.bind(this), 5000);
                 }.bind(this));
         },
     });

--- a/views/module/admin/conveyer.pug
+++ b/views/module/admin/conveyer.pug
@@ -35,13 +35,13 @@
             div(data-bind="css: {'text-success': conveyerEnabled(), 'text-error': !conveyerEnabled()}, text: conveyerEnabled() ? 'Конвейер активен' : 'Конвейер остановлен'")
             div
                 span.stateRate(data-bind="text:converted()")
-                span.stateDesc Конвертированно с песледней 10-минутки
+                span.stateDesc Конвертировано за текущую 10-ти минутку
             div
                 span.stateRate(data-bind="text:clength()")
-                span.stateDesc Длина конвейера
+                span.stateDesc Текущая длина конвейера
             div
                 span.stateRate(data-bind="text:cmaxlength()")
-                span.stateDesc Максимальная длина конвейера с песледней 10-минутки
+                span.stateDesc Максимальная длина конвейера за текущую 10-ти минутку
     br
     h5 Сконвертированно
     #conveyerConvertGraph


### PR DESCRIPTION
Quick fix not to list a "confusing" value of conversion queue. Due to the fact that conveyer is run on all instances and can process images from the different instances, the queue size variable may reflect incorrect value. The patch updates it from the DB on each stats recording.