### PR TITLE
Use maxDistance in nearSphere calls to improve its performance.

### DIFF
--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1257,10 +1257,14 @@ async function approve(data) {
 
     const oldPhotoObj = photo.toObject();
 
+    // Publish photo.
     photo.s = status.PUBLIC;
     photo.stdate = photo.cdate = photo.adate = photo.sdate = new Date();
 
     const { rel } = await this.call('photo.update', { photo });
+
+    // Save previous status to history
+    await this.call('photo.saveHistory', { oldPhotoObj, photo, canModerate });
 
     await Promise.all([
         // Recalculate the number of photos of the owner
@@ -1277,9 +1281,6 @@ async function approve(data) {
     if (Utils.geo.check(photo.geo)) {
         await this.call('photo.photoToMap', { photo, paintingMap: photo.type === constants.photo.type.PAINTING });
     }
-
-    // Save previous status to history
-    await this.call('photo.saveHistory', { oldPhotoObj, photo, canModerate });
 
     this.call('photo.changeFileProtection', { photo, protect: false });
 


### PR DESCRIPTION
This patch improves `nearSphere` performance by specifying `maxDistance` equal to distance from cluster geo center to its corner. Without `maxDistance` the method tend to respond slower as it builds searching circle bigger than required.

Also this patch is moving photo changes history recording before adding to map, so that we don't loose "Publish" history record if it fails in the middle for whatever reason.

Referencing #447 as related.