### PR TITLE
Migrate from legacy analytics (UA to GA4)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
     'globals': {
         '__DEV__': 'readonly',
         'ga': 'readonly',
+        'gtag': 'readonly',
     },
 
     'plugins': [

--- a/config/default.config.js
+++ b/config/default.config.js
@@ -103,6 +103,13 @@ module.exports = {
         yandexMaps: process.env.YANDEX_MAPS_API_KEY || '',
     },
 
+    // Google Analytics (gtag.js) tagging framework and API. Make sure "Page
+    // changes based on browser history events" is not ticked at Enhanced
+    // Management interface, otherwise page view events will have duplicates.
+    analytics: {
+        trackingID: process.env.GA_TRACKING_ID || '', // Google Analytics destination ID of G-XXXXXXXX format.
+    },
+
     // Default home region for new user
     regionHome: 2,
 

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -96,7 +96,6 @@ export const getPlainUser = (function () {
         // Transforms are applied to the document and each of its sub-documents.
         // Check that it's exactly user
         if (doc.login !== undefined) {
-            delete ret.cid;
             delete ret.pass;
             delete ret.activatedate;
             delete ret.loginAttempts;

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -26,9 +26,9 @@ const getUserRanks = () => constants.user.ranks;
 // Fill object for client parameters
 async function fillClientParams() {
     const settings = await Settings.find({}, { _id: 0, key: 1, val: 1 }, { lean: true }).exec();
-    const { lang, hash, publicApiKeys, version, docs } = config;
+    const { lang, hash, publicApiKeys, analytics, version, docs, env } = config;
 
-    Object.assign(clientParams, { lang, hash, publicApiKeys, version, docs });
+    Object.assign(clientParams, { lang, hash, publicApiKeys, analytics, version, docs, env });
 
     for (const setting of settings) {
         clientParams[setting.key] = setting.val;

--- a/public/js/Params.js
+++ b/public/js/Params.js
@@ -44,7 +44,9 @@ define(['jquery', 'underscore', 'socket!', 'Utils', 'knockout', 'knockout.mappin
 
     // Create Params view model, define properties that will not be observable
     // when view model is converted to JS object.
-    Params = koMapping.fromJS(Params, { copy: ['window.head', 'settings.lang', 'settings.publicApiKeys', 'settings.docs'] });
+    const noObserve = ['window.head', 'settings.lang', 'settings.publicApiKeys', 'settings.analytics', 'settings.docs', 'settings.env'];
+
+    Params = koMapping.fromJS(Params, { copy: noObserve });
 
     // Пересчитываем размеры при ресайзе окна
     $window.on('resize', _.debounce(function () {

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+define(['underscore', 'Params'], function (_, P) {
+    'use strict';
+
+    /**
+     * Initialise GA4
+     *
+     * @param {object} additionalConfigInfo
+     */
+    const install = function(additionalConfigInfo = {}) {
+        const trackingID = P.settings.analytics.trackingID;
+
+        if (!trackingID) {
+            return;
+        }
+
+        // Once script is loaded, it will process dataLayer queue, so no need to wait.
+        require([`https://www.googletagmanager.com/gtag/js?id=${trackingID}`]);
+
+        window.dataLayer = window.dataLayer || [];
+
+        gtag('js', new Date());
+        gtag('config', trackingID, additionalConfigInfo);
+    };
+
+    /**
+     * Send data to Google Analytics.
+     */
+    window.gtag = function () {
+        if (window.dataLayer) {
+            window.dataLayer.push(arguments);
+        }
+    };
+
+    /**
+     * Proxy legacy analytics.js (UA) events to gtag.js (GA4).
+     *
+     * This function may be removed when all legacy ga events are migrated.
+     * legacy ref: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+     */
+    window.ga = function () {
+        const args = _.toArray(arguments);
+        const pluginName = args.shift();
+        const methodName = args.shift();
+
+        // Proxy GA events.
+        if (pluginName === 'send' && methodName === 'event') {
+            const [eventCategory, eventAction, eventLabel, eventValue] = args;
+
+            gtag('event', eventAction, {
+                'event_category': eventCategory,
+                'event_label': eventLabel,
+                'value': eventValue,
+            });
+        }
+    };
+
+    return {
+        install: install,
+        setUserID: setUserID,
+    };
+});

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -6,12 +6,16 @@
 define(['underscore', 'Params'], function (_, P) {
     'use strict';
 
+    const config = {
+        send_page_view: false, // In single page app we take control over page view event.
+    };
+
     /**
      * Initialise GA4
      *
-     * @param {object} additionalConfigInfo
+     * @param {object} additionalConfig
      */
-    const install = function(additionalConfigInfo = {}) {
+    const install = function (additionalConfig = {}) {
         const trackingID = P.settings.analytics.trackingID;
 
         if (!trackingID) {
@@ -23,8 +27,12 @@ define(['underscore', 'Params'], function (_, P) {
 
         window.dataLayer = window.dataLayer || [];
 
+        if (P.settings.env === 'development') {
+            config.debug_mode = true; // Allow to monitor events in DebugView admin interface.
+        }
+
         gtag('js', new Date());
-        gtag('config', trackingID, additionalConfigInfo);
+        gtag('config', trackingID, _.defaults(additionalConfig, config));
     };
 
     /**

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -36,6 +36,16 @@ define(['underscore', 'Params'], function (_, P) {
     };
 
     /**
+     * Set user ID for enhanced user analytics across devices and sessions.
+     * https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtag
+     *
+     * @param {number} userID
+     */
+    const setUserID = function (userID) {
+        gtag('config', P.settings.analytics.trackingID, { 'user_id': userID });
+    };
+
+    /**
      * Send data to Google Analytics.
      */
     window.gtag = function () {

--- a/public/js/model/User.js
+++ b/public/js/model/User.js
@@ -33,6 +33,7 @@ define(['jquery', 'underscore', 'Utils', 'knockout', 'knockout.mapping', 'Params
             email: '',
             firstName: '',
             lastName: '',
+            cid: 0,
 
             role: 0,
 

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -5,10 +5,10 @@
 
 require([
     'domReady!', 'jquery', 'Browser', 'Utils', 'socket!', 'underscore', 'knockout', 'moment',
-    'globalVM', 'Params', 'renderer', 'router', 'model/Photo', 'model/User', 'noties',
+    'globalVM', 'Params', 'renderer', 'router', 'model/Photo', 'model/User', 'noties', 'analytics',
     'text!tpl/appMain.pug', 'css!style/appMain', 'momentlang/ru', 'bs/transition', 'bs/popover',
     'knockout.extends', 'noty', 'noty.layouts', 'noty.themes/pastvu', 'jquery-plugins/scrollto',
-], function (domReady, $, Browser, Utils, socket, _, ko, moment, globalVM, P, renderer, router, Photo, User, noties, html) {
+], function (domReady, $, Browser, Utils, socket, _, ko, moment, globalVM, P, renderer, router, Photo, User, noties, analytics, html) {
     'use strict';
 
     Utils.title.setPostfix('Фотографии прошлого');
@@ -43,7 +43,6 @@ require([
         handlers: {
             index: function (qparams) {
                 router.params(_.assign({ _handler: 'index' }, qparams));
-                ga('set', 'page', '/');
 
                 renderer(
                     [
@@ -59,7 +58,6 @@ require([
                 }
 
                 router.params(_.assign({ cid: cid, _handler: 'photo' }, qparams));
-                ga('set', 'page', '/p' + (cid ? '/' + cid : ''));
                 renderer(
                     [
                         { module: 'm/photo/photo', container: '#bodyContainer' },
@@ -68,7 +66,12 @@ require([
             },
             photos: function (page, qparams) {
                 router.params(_.assign({ page: page, _handler: 'gallery' }, qparams));
-                ga('set', 'page', '/ps' + (page ? '/' + page : ''));
+
+                if (page !== 'feed' && page !== 'coin') {
+                    // Suppress numbered pagination in analytics.
+                    gtag('set', 'page_path', '/ps');
+                }
+
                 renderer(
                     [
                         { module: 'm/photo/gallery', container: '#bodyContainer', options: { } },
@@ -84,6 +87,8 @@ require([
 
                 if (!section) {
                     section = 'profile';
+                    // Override page_path to reflect /profile for the default user page location in analytics.
+                    gtag('set', 'page_path', `/u/${login}/profile`);
                 }
 
                 router.params(_.assign({
@@ -93,7 +98,6 @@ require([
                     _handler: 'profile',
                 }, qparams));
 
-                ga('set', 'page', '/u' + (login ? '/' + login + (section ? '/' + section : '') : ''));
                 renderer(
                     [
                         { module: 'm/user/userPage', container: '#bodyContainer' },
@@ -103,7 +107,6 @@ require([
             photoUpload: function () {
                 router.params({ section: 'photo', photoUpload: true, _handler: 'profile' });
 
-                ga('set', 'page', '/photoUpload');
                 renderer(
                     [
                         { module: 'm/user/userPage', container: '#bodyContainer' },
@@ -128,7 +131,6 @@ require([
                 const mName = cid ? 'm/diff/news' : 'm/diff/newsList';
 
                 router.params(_.assign({ cid: cid, _handler: 'news' }, qparams));
-                ga('set', 'page', '/news' + (cid ? '/' + cid : ''));
                 renderer(
                     [
                         { module: mName, container: '#bodyContainer' },
@@ -144,8 +146,10 @@ require([
                     .then(function (data) {
                         renderer([{ module: 'm/main/mainPage', container: '#bodyContainer' }]);
 
-                        ga('set', 'page', '/confirm');
-                        ga('send', 'pageview', { title: 'Confirm' });
+                        gtag('event', 'page_view', {
+                            page_title: 'Confirm',
+                            page_path: '/confirm',
+                        });
 
                         if (data.type === 'noty') {
                             noties.alert({
@@ -177,6 +181,11 @@ require([
 
     $('body').append(html);
     ko.applyBindings(globalVM);
+
+    analytics.install({
+        debug_mode: P.settings.env === 'development', // Enable to use DebugView in Analytics admin interface.
+        send_page_view: false, // In single page app we take control over page view event.
+    });
 
     globalVM.router = router.init(routerAnatomy);
     $.when(routerDeferred.promise()).then(function () {

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -182,10 +182,8 @@ require([
     $('body').append(html);
     ko.applyBindings(globalVM);
 
-    analytics.install({
-        debug_mode: P.settings.env === 'development', // Enable to use DebugView in Analytics admin interface.
-        send_page_view: false, // In single page app we take control over page view event.
-    });
+    // Initialise Google Analytics.
+    analytics.install();
 
     globalVM.router = router.init(routerAnatomy);
     $.when(routerDeferred.promise()).then(function () {

--- a/public/js/module/common/auth.js
+++ b/public/js/module/common/auth.js
@@ -4,7 +4,7 @@
  */
 
 /*global init:true */
-define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'm/_moduleCliche', 'globalVM', 'model/storage', 'model/User', 'text!tpl/common/auth.pug', 'css!style/common/auth'], function (_, $, Utils, socket, P, ko, Cliche, globalVM, storage, User, pug) {
+define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'analytics', 'knockout', 'm/_moduleCliche', 'globalVM', 'model/storage', 'model/User', 'text!tpl/common/auth.pug', 'css!style/common/auth'], function (_, $, Utils, socket, P, analytics, ko, Cliche, globalVM, storage, User, pug) {
     'use strict';
 
     //Обновляет куки сессии переданным объектом с сервера
@@ -391,7 +391,11 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'knockout', 'm/_mo
 
             if (loggedIn) {
                 this.loggedIn(loggedIn); //loggedIn должен изменятся после обновления storage, так как на него есть зависимые подписки
+                analytics.setUserID(user.cid);
+            } else {
+                analytics.setUserID(null);
             }
+
 
             //Поднимаем версию пользователя, с помощью которой есть подписки на обновление iAm
             this.iAm._v_(user._v_ + 1);

--- a/public/js/module/common/auth.js
+++ b/public/js/module/common/auth.js
@@ -232,7 +232,7 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'analytics', 'knoc
                             setTimeout(function () {
                                 self.formWorking(false);
                             }, 420);
-                            ga('send', 'event', 'auth', 'register', 'auth register success');
+                            ga('send', 'event', 'auth', 'sign_up', 'auth sign up success');
                         },
                         function (data) {
                             self.setMessage(data.message, 'error');
@@ -240,7 +240,7 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'analytics', 'knoc
                                 self.formFocus();
                                 self.formWorking(false);
                             }, 420);
-                            ga('send', 'event', 'auth', 'register', 'auth register error');
+                            ga('send', 'event', 'auth', 'sign_up', 'auth sign up error');
                         }
                     );
                 } else if (self.mode() === 'recallRequest') {

--- a/public/js/module/common/share.js
+++ b/public/js/module/common/share.js
@@ -56,7 +56,7 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'globalVM', 'knock
 
             socials.forEach(function (social) {
                 social.action = function (data, evt) {
-                    self.share(social.id, data, evt);
+                    self.share(social.id, social.name, data, evt);
                 };
             });
 
@@ -89,7 +89,7 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'globalVM', 'knock
                 input.select();
             }
         },
-        share: function (network) {
+        share: function (network, networkName) {
             let url;
             const origin = location.origin || location.protocol + '://' + location.host;
             const options = this.options;
@@ -152,7 +152,11 @@ define(['underscore', 'jquery', 'Utils', 'socket!', 'Params', 'globalVM', 'knock
                     '&counturl=' + pageUrl;
             }
 
-            ga('send', 'event', 'share', network, 'share network click');
+            gtag('event', 'share', {
+                method: networkName,
+                content_type: 'url',
+                item_id: options.linkPage,
+            });
         },
     });
 });

--- a/public/js/module/diff/about.js
+++ b/public/js/module/diff/about.js
@@ -17,7 +17,6 @@ define(['underscore', 'Params', 'socket!', 'knockout', 'm/_moduleCliche', 'globa
 
             socket.run('index.giveAbout').then(function (result) {
                 ga('send', 'event', 'about', 'open', 'about open');
-                // ga('send', 'pageview', {'page': '/about', 'title': 'О проекте'});
 
                 self.avatars = result || {};
 

--- a/public/js/module/diff/news.js
+++ b/public/js/module/diff/news.js
@@ -101,7 +101,7 @@ define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mappin
                     });
 
                     this.makeBinding();
-                    ga('send', 'pageview');
+                    gtag('event', 'page_view');
                 }, this);
             } else if (this.toComment) {
                 this.scrollTimeout = window.setTimeout(this.scrollToBind, 50);

--- a/public/js/module/diff/newsList.js
+++ b/public/js/module/diff/newsList.js
@@ -47,7 +47,7 @@ define([
         routeHandler: function () {
             this.getAllNews(function (/*data*/) {
                 Utils.title.setTitle({ title: 'Новости' });
-                ga('send', 'pageview');
+                gtag('event', 'page_view');
             });
         },
         getAllNews: function (cb, ctx) {

--- a/public/js/module/main/mainPage.js
+++ b/public/js/module/main/mainPage.js
@@ -48,7 +48,7 @@ define(['underscore', 'Utils', 'Params', 'knockout', 'knockout.mapping', 'm/_mod
             this.sizesCalc();
             globalVM.func.showContainer(this.$container);
             this.showing = true;
-            ga('send', 'pageview');
+            gtag('event', 'page_view');
         },
         hide: function () {
             globalVM.func.hideContainer(this.$container);

--- a/public/js/module/photo/gallery.js
+++ b/public/js/module/photo/gallery.js
@@ -378,7 +378,7 @@ define([
             this.page(page);
 
             if (!this.u) {
-                ga('send', 'pageview'); //В галерее пользователя pageview отправляет userPage
+                gtag('event', 'page_view'); //В галерее пользователя page_view отправляет userPage
             }
 
             if (needRecieve || filterChange) {

--- a/public/js/module/photo/photo.js
+++ b/public/js/module/photo/photo.js
@@ -448,7 +448,7 @@ define(['underscore', 'Utils', 'socket!', 'Params', 'knockout', 'knockout.mappin
                         self.destroyHistory();
                     }
 
-                    ga('send', 'pageview', '/p');
+                    gtag('event', 'page_view');
                 }, this);
             } else {
                 if (self.toFrag || self.toComment) {

--- a/public/js/module/user/userPage.js
+++ b/public/js/module/user/userPage.js
@@ -233,7 +233,7 @@ define(['underscore', 'Utils', 'Params', 'renderer', 'knockout', 'knockout.mappi
             }
 
             this.section(section);
-            ga('send', 'pageview');
+            gtag('event', 'page_view');
 
             if (!this.contentVM || this.contentVM.module !== module) {
                 moduleOptions.module = module;

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -61,8 +61,8 @@ define(['jquery', 'underscore', 'Utils', 'knockout', 'globalVM', 'renderer'], fu
 
         routes: [],
         handlers: {},
-        addRoute: function (route, handler, ctx) {
-            router.routes.push({ route: route, handler: handler, ctx: ctx });
+        addRoute: function (route, handler) {
+            router.routes.push({ route: route, handler: handler });
         },
         addHandler: function (name, func) {
             router.handlers[name] = _.wrap(func, router.handlerWrapper);
@@ -101,16 +101,19 @@ define(['jquery', 'underscore', 'Utils', 'knockout', 'globalVM', 'renderer'], fu
         triggerUrl: function () {
             const qparams = Utils.getURLParameters(location.href);
             const pathname = location.pathname;
-            let matchedArgs;
-            let handler;
+
+            // Set page_path early, so handler may override it if needed.
+            gtag('set', 'page_path', pathname);
+
             let triggered = false;
 
             router.routes.forEach(function (item) {
                 if (item.route.test(pathname)) {
-                    handler = router.handlers[item.handler];
+                    const handler = router.handlers[item.handler];
 
                     if (_.isFunction(handler)) {
-                        matchedArgs = _.chain(pathname.match(item.route)).toArray().tail().value();
+                        const matchedArgs = _.chain(pathname.match(item.route)).toArray().tail().value();
+
                         matchedArgs.push(qparams);
                         handler.apply(item.ctx, matchedArgs);
                         triggered = true;

--- a/views/app.pug
+++ b/views/app.pug
@@ -9,13 +9,6 @@ html
             if polyfills.promise
                 script(type="text/javascript", src='/js/lib/es6-promise.min.js')
 
-        if config.env === 'production'
-            script.
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create','UA-42731294-1','auto');ga('require','displayfeatures');
-        else
-            script.
-                function ga() {}
-
         link(rel="stylesheet", href="/style/common.css")
 
         | <script type="text/javascript">


### PR DESCRIPTION
Some changes alongside this upgrade:
* Google tag ID is moved to configuration (`analytics.trackingID`) and optionaly can be set using `GA_TRACKING_ID` env variable
* If tag ID is not set, analytics script will not be loaded (configured default for non-prod environment).
* When tag ID is configured in dev environment, debugging is enabled and events can be observed using [DebugView](https://support.google.com/analytics/answer/7201382?hl=en).
* Added support of  User ID feature for analysis across sessions and devices (`user.cid` seems qualifies as non-PII), [more info](https://support.google.com/analytics/answer/9213390).
* Some events are renamed/adjusted to match GA standard ([recommended](https://support.google.com/analytics/answer/9267735)) ones.
* Photos full URL is used in pageview event (previously aggregared to `/p`)
* Gallery pages are aggregated as `/ps` in pageview event

Legacy `ga()` function is implemented as `gtag()` wrapper, this allowed to minimise number of changes, we may eventually remove it when all `ga` calls are migrated.

Google Tag Manager support is not implemented at this point.





