### PR TITLE
Analytics fixes

### DIFF
--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -42,7 +42,8 @@ define(['underscore', 'Params'], function (_, P) {
      * @param {number} userID
      */
     const setUserID = function (userID) {
-        gtag('config', P.settings.analytics.trackingID, { 'user_id': userID });
+        // Set globally, it does not seem update configuration at this stage.
+        gtag('set', 'user_id', userID);
     };
 
     /**

--- a/public/js/analytics.js
+++ b/public/js/analytics.js
@@ -8,6 +8,9 @@ define(['underscore', 'Params'], function (_, P) {
 
     const config = {
         send_page_view: false, // In single page app we take control over page view event.
+        user_properties: {
+            app_language: P.settings.lang,
+        },
     };
 
     /**

--- a/public/js/module/appMain.js
+++ b/public/js/module/appMain.js
@@ -69,7 +69,7 @@ require([
 
                 if (page !== 'feed' && page !== 'coin') {
                     // Suppress numbered pagination in analytics.
-                    gtag('set', 'page_path', '/ps');
+                    gtag('set', 'page_location', location.origin + '/ps');
                 }
 
                 renderer(
@@ -87,8 +87,8 @@ require([
 
                 if (!section) {
                     section = 'profile';
-                    // Override page_path to reflect /profile for the default user page location in analytics.
-                    gtag('set', 'page_path', `/u/${login}/profile`);
+                    // Override page_location to reflect /profile for the default user page location in analytics.
+                    gtag('set', 'page_location', location.origin + `/u/${login}/profile`);
                 }
 
                 router.params(_.assign({
@@ -148,7 +148,7 @@ require([
 
                         gtag('event', 'page_view', {
                             page_title: 'Confirm',
-                            page_path: '/confirm',
+                            page_location: location.origin + '/confirm',
                         });
 
                         if (data.type === 'noty') {

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -102,8 +102,8 @@ define(['jquery', 'underscore', 'Utils', 'knockout', 'globalVM', 'renderer'], fu
             const qparams = Utils.getURLParameters(location.href);
             const pathname = location.pathname;
 
-            // Set page_path early, so handler may override it if needed.
-            gtag('set', 'page_path', pathname);
+            // Set page_location early, so handler may override it if needed.
+            gtag('set', 'page_location', location.origin + location.pathname);
 
             let triggered = false;
 


### PR DESCRIPTION
1. Use page_location param for page_view event, as `page_path` is treated as custom param in GA4 (has no effect), docs [here](https://developers.google.com/analytics/devguides/migration/measurement/virtual-pageviews#example_of_ua_and_ga4_virtual_pageviews)
2. Fix analytics User ID. It needs to be defined globally (using set command) if called after initial config.
3. Set app language in user property, so it can be used as dimension in reports.