### PR TITLE
Renamed past.lang cookie

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
   push:
     branches:
-      - 'master'
+      - '**'
     tags:
       - 'v*'
   workflow_dispatch:

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -46,7 +46,7 @@ export const createSidCookieObj = (function () {
 
 // Create cookie lang object (temporary)
 const createLangCookieObj = (function () {
-    const key = 'past.lang';
+    const key = 'past_lang';
     const domain = config.client.hostname;
     const cookieUserMaxAge = SESSION_USER_LIFE / 1000;
     const cookieAnonMaxAge = SESSION_ANON_LIFE / 1000;


### PR DESCRIPTION
Renamed `past.lang` cookie, so now can be parsed easily by `nginx`.