### PR TITLE
Impelement latest comment in tree link and badge.

### DIFF
--- a/public/js/module/comment/comments.js
+++ b/public/js/module/comment/comments.js
@@ -66,6 +66,7 @@ define([
             this.count = ko.observable(this.options.count || 0);
             this.countNew = ko.observable(this.options.countNew || 0);
             this.countDel = ko.observable(0);
+            this.latestCommentStamp = ko.observable(0);
             this.subscr = ko.observable(this.options.subscr || false);
             this.nocomments = ko.observable(this.options.nocomments);
             this.canReply = ko.observable(this.options.canReply);
@@ -393,6 +394,7 @@ define([
                     this.countDel(data.countDel || 0);
                     this.canModerate(canModerate);
                     this.canReply(canReply);
+                    this.latestCommentStamp(data.latestCommentStamp);
 
                     if (Utils.isType('function', cbBeforeRender)) {
                         cbBeforeRender.call(ctx, data);
@@ -496,6 +498,8 @@ define([
                 if (this.countNew()) {
                     this.navCheckBefore(0, true);
                 }
+            } else if (ccid === 'latest') {
+                $element = $('.latest', this.$cmts);
             } else {
                 $element = $('#c' + ccid, this.$cmts);
                 highlight = true;
@@ -541,7 +545,9 @@ define([
         highlightOff: function () {
             $('.c.hl', this.$cmts).removeClass('hl');
         },
-
+        getLatestCommentStamp: function () {
+            return formatDateRelative(new Date(this.latestCommentStamp()));
+        },
         // Создаёт поле ввода комментария. Ответ или редактирование
         inputCreate: function (relatedComment, $cedit) {
             let $cadd;
@@ -1235,6 +1241,13 @@ define([
                 comment.user = self.users[comment.user];
                 comment.can.edit = true;
                 comment.can.del = true;
+
+                // New comment is the latest, remove previous latest comment highlight.
+                comment.latest = true;
+                $('.badge-latest', self.$cmts).prev('.dotDelimeter').remove();
+                $('.badge-latest', self.$cmts).remove();
+                $('.latest', self.$cmts).removeClass('latest');
+                self.latestCommentStamp(comment.stamp);
 
                 self.commentsHash[comment.cid] = comment;
 

--- a/public/style/comment/comments.less
+++ b/public/style/comment/comments.less
@@ -1,6 +1,7 @@
 @import '../_vars.less';
 @import '../bs/variables.less';
 @import '../bs/mixins.less';
+@import '../bs/badges.less';
 
 @headColor: #677A8F;
 @headColorHover: @MainBlueColor;
@@ -26,6 +27,10 @@
         background-image: url(/img/misc/load.gif);
         background-repeat: no-repeat;
         background-position: 0 50%;
+    }
+
+    .commentsLatest {
+        margin-left: 8px;
     }
 
     > .cmtsHead {
@@ -131,6 +136,13 @@
 
             .levelLooping(0, 58);
 
+            .badge {
+                font-size: 11px;
+                font-weight: normal;
+                color: #f2f2f2;
+                background-color: rgba(85, 85, 85, 80%);
+            }
+
             &.isnew {
                 padding-left: 5px;
                 border-width: 0 0 0 1px;
@@ -138,6 +150,7 @@
                 border-color: #81df7d;
                 background-color: rgba(174, 255, 184, 30%);
             }
+
             //Редактируемый комментарий скрывается, заменяясь на поле ввода
             &.edit {
                 display: none;

--- a/views/module/comment/cdotanonym.pug
+++ b/views/module/comment/cdotanonym.pug
@@ -1,4 +1,4 @@
-.c(id="c{{=c.cid}}", class="l{{=c.level}}")
+.c(id="c{{=c.cid}}", class="l{{=c.level}}{{?c.latest}} latest{{?}}")
     a.hrefava(href="{{='/u/'+c.user.login}}")
         | {{?c.user.avatar === undefined}}
         .overprint {{=c.user.disp[0]}}
@@ -21,5 +21,9 @@
             | {{?c.lastChanged}}
             .dotDelimeter ·
             .changed(title="Показать историю изменений") {{='Изменен '+it.fDateIn(new Date(c.lastChanged))}}
+            | {{?}}
+            | {{?c.latest}}
+            .dotDelimeter ·
+            .badge.badge-latest Последний комментарий
             | {{?}}
         .ctext {{=c.txt}}

--- a/views/module/comment/cdotauth.pug
+++ b/views/module/comment/cdotauth.pug
@@ -1,7 +1,7 @@
 | {{?c.del===true}}
 | {{#def.del}}
 | {{??}}
-.c(id="c{{=c.cid}}", class="l{{=c.level}}{{?c.isnew}} isnew{{?}}")
+.c(id="c{{=c.cid}}", class="l{{=c.level}}{{?c.isnew}} isnew{{?}}{{?c.latest}} latest{{?}}")
     a.hrefava(href="{{='/u/'+c.user.login}}", target="_blank")
         | {{?c.user.avatar === undefined}}
         .overprint {{=c.user.disp[0]}}
@@ -24,6 +24,10 @@
             | {{?c.lastChanged}}
             .dotDelimeter ·
             .changed(title="Показать историю изменений") {{='Изменен '+it.fDateIn(new Date(c.lastChanged))}}
+            | {{?}}
+            | {{?c.latest}}
+            .dotDelimeter ·
+            .badge.badge-latest Последний комментарий
             | {{?}}
         .ctext {{=c.txt}}
         .cacts

--- a/views/module/comment/comments.pug
+++ b/views/module/comment/comments.pug
@@ -30,6 +30,9 @@
         span.cantComment Комментирование запрещено
         // /ko
         .commentsLoad(data-bind="style: {display: loading() ? '' : 'none'}") &nbsp;
+        //ko if: !loading() && count()
+        a.commentsLatest.stamp(data-replace="true", href="?hl=comment-latest", data-bind="text: 'Последний комментарий: ' + getLatestCommentStamp()")
+        // /ko
 
     .cmts
 


### PR DESCRIPTION
Per [ #630](https://github.com/PastVu/pastvu/issues/630#issuecomment-1794047625), the implementation includes:
* Latest comment badge (we will use this component more in future, e.g. to highlight moderators #43)
* The link at the comment header showing latest comment time
* `?hl=comment-latest` anchor.
* When addin new comment, the new comment becomes the latest.

![image](https://github.com/PastVu/pastvu/assets/329780/2620f96c-10ae-4787-8d32-c7bea8042b1e)
