### PR TITLE
Address missing history issue

### DIFF
--- a/app/errors/constants.js
+++ b/app/errors/constants.js
@@ -91,8 +91,6 @@ export default Utils.reflectKeys({
     CONVERT_PHOTOS_ALL: null,
     CONVERT_PROMISE_GENERATOR: null,
 
-    HISTORY_DOESNT_EXISTS: null,
-
     SETTING_DOESNT_EXISTS: null,
 
     MAIL_SEND: null,

--- a/app/errors/intl.js
+++ b/app/errors/intl.js
@@ -87,8 +87,6 @@ export default {
     CONVERT_PHOTOS_ALL: 'Ошибка отправки на конвертацию',
     CONVERT_PROMISE_GENERATOR: 'Ошибка выполнения операции в конвейере конвертации',
 
-    HISTORY_DOESNT_EXISTS: 'Для объекта еще нет истории',
-
     SETTING_DOESNT_EXISTS: 'Такой настройки не существует',
 
     MAIL_SEND: 'Ошибка отправки письма',

--- a/views/module/photo/hist.pug
+++ b/views/module/photo/hist.pug
@@ -65,6 +65,12 @@
                 | Комментирование {{?h.values.nocomments}}запрещено{{??}}разрешено{{?}}
             | {{?}}
 
+            | {{?h.values.histmissing}}
+            .info.iconed.red
+                span.glyphicon(class="glyphicon-floppy-remove")
+                | Доступна не вся история изменений
+            | {{?}}
+
             | {{?h.reason}}
             .value
                 .name Причина


### PR DESCRIPTION
* When photo history is accessed, show upload time with notification that some changes history is missing (but do not add history record to db).
![image](https://github.com/PastVu/pastvu/assets/329780/96010698-1c8c-4bb4-87f9-f47619be200c)

* When editing a photo with missing history, add first history record to db with upload time and notification that some history is missing.
![image](https://github.com/PastVu/pastvu/assets/329780/dd6eda2c-1a8b-456f-92d4-6cf29d1800b1)

Doing this through migration is time consuming, so decided to do this on per access/edit basis.

Fixes #631