### PR TITLE
Replace latest comment badge with highlight instead

### DIFF
--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -107,16 +107,13 @@ function commentsTreeBuildAnonym(comments, usersHash) {
     }
 
     // Set latest comment flag.
-    let latestCommentStamp = 0;
-
     if (latestCid) {
         const latestComment = hash[latestCid];
 
         latestComment.latest = true;
-        latestCommentStamp = latestComment.stamp;
     }
 
-    return { tree, latestCommentStamp };
+    return { tree, latestCid };
 }
 
 async function commentsTreeBuildAuth({ iAm, type, commentModel, obj, canReply, showDel }) {
@@ -260,13 +257,10 @@ async function commentsTreeBuildAuth({ iAm, type, commentModel, obj, canReply, s
     }
 
     // Set latest comment flag.
-    let latestCommentStamp = 0;
-
     if (latestCid) {
         const latestComment = commentsHash[latestCid];
 
         latestComment.latest = true;
-        latestCommentStamp = latestComment.stamp;
     }
 
     const { usersById, usersByLogin } = await getUsersHashForComments(usersSet);
@@ -312,7 +306,7 @@ async function commentsTreeBuildAuth({ iAm, type, commentModel, obj, canReply, s
         }
     }
 
-    return { tree: commentsTree, users: usersByLogin, countTotal, countNew, countDel, latestCommentStamp };
+    return { tree: commentsTree, users: usersByLogin, countTotal, countNew, countDel, latestCid };
 }
 
 async function commentsTreeBuildCanModerate({ iAm, type, commentModel, obj, showDel }) {
@@ -413,12 +407,10 @@ async function commentsTreeBuildCanModerate({ iAm, type, commentModel, obj, show
 
     // Set latest comment flag.
     const latestComment = commentsMap.get(latestCid);
-    let latestCommentStamp = 0;
 
     if (latestComment) {
         latestComment.latest = true;
         commentsMap.set(latestCid, latestComment);
-        latestCommentStamp = latestComment.stamp;
     }
 
     const { usersById, usersByLogin } = await getUsersHashForComments(usersSet);
@@ -427,7 +419,7 @@ async function commentsTreeBuildCanModerate({ iAm, type, commentModel, obj, show
         comment.user = usersById[comment.user].login;
     }
 
-    return { tree: commentsTree, users: usersByLogin, countTotal, countNew, countDel, latestCommentStamp };
+    return { tree: commentsTree, users: usersByLogin, countTotal, countNew, countDel, latestCid };
 }
 
 async function commentsTreeBuildDel(comment, childs, checkMyId) {
@@ -559,14 +551,14 @@ async function getCommentsObjAnonym({ cid, type = 'photo' }) {
     let tree;
     let usersById;
     let usersByLogin;
-    let latestCommentStamp = 0;
+    let latestCid = 0;
 
     if (usersSet.size) {
         ({ usersById, usersByLogin } = await getUsersHashForComments(usersSet));
-        ({ tree, latestCommentStamp } = commentsTreeBuildAnonym(comments, usersById));
+        ({ tree, latestCid } = commentsTreeBuildAnonym(comments, usersById));
     }
 
-    return { comments: tree || [], countTotal: comments.length, users: usersByLogin, latestCommentStamp };
+    return { comments: tree || [], countTotal: comments.length, users: usersByLogin, latestCid };
 }
 
 async function getCommentsObjAuth({ cid, type = 'photo', showDel = false }) {
@@ -590,14 +582,14 @@ async function getCommentsObjAuth({ cid, type = 'photo', showDel = false }) {
     const canModerate = permissions.canModerate(type, obj, iAm);
     const canReply = permissions.canReply(type, obj, iAm);
 
-    const { tree, users, countTotal, countNew, countDel, latestCommentStamp } = await (canModerate ?
+    const { tree, users, countTotal, countNew, countDel, latestCid } = await (canModerate ?
         // Если это модератор данной фотографии или администратор новости
         commentsTreeBuildCanModerate({ iAm, type, commentModel, obj, showDel }) :
         // Если это зарегистрированный пользователь
         commentsTreeBuildAuth({ iAm, type, commentModel, obj, canReply, showDel })
     );
 
-    return { comments: tree, users, countTotal, countNew, countDel, canModerate, canReply, latestCommentStamp };
+    return { comments: tree, users, countTotal, countNew, countDel, canModerate, canReply, latestCid };
 }
 
 // Select comments for object

--- a/public/js/module/comment/comments.js
+++ b/public/js/module/comment/comments.js
@@ -66,7 +66,7 @@ define([
             this.count = ko.observable(this.options.count || 0);
             this.countNew = ko.observable(this.options.countNew || 0);
             this.countDel = ko.observable(0);
-            this.latestCommentStamp = ko.observable(0);
+            this.latestCommentCid = ko.observable(0);
             this.subscr = ko.observable(this.options.subscr || false);
             this.nocomments = ko.observable(this.options.nocomments);
             this.canReply = ko.observable(this.options.canReply);
@@ -394,7 +394,7 @@ define([
                     this.countDel(data.countDel || 0);
                     this.canModerate(canModerate);
                     this.canReply(canReply);
-                    this.latestCommentStamp(data.latestCommentStamp);
+                    this.latestCommentCid(data.latestCid);
 
                     if (Utils.isType('function', cbBeforeRender)) {
                         cbBeforeRender.call(ctx, data);
@@ -500,6 +500,8 @@ define([
                 }
             } else if (ccid === 'latest') {
                 $element = $('.latest', this.$cmts);
+                ccid = this.latestCommentCid();
+                highlight = true;
             } else {
                 $element = $('#c' + ccid, this.$cmts);
                 highlight = true;
@@ -546,7 +548,11 @@ define([
             $('.c.hl', this.$cmts).removeClass('hl');
         },
         getLatestCommentStamp: function () {
-            return formatDateRelative(new Date(this.latestCommentStamp()));
+            if (this.commentsHash[this.latestCommentCid()]) {
+                return formatDateRelative(new Date(this.commentsHash[this.latestCommentCid()].stamp));
+            }
+
+            return '';
         },
         // Создаёт поле ввода комментария. Ответ или редактирование
         inputCreate: function (relatedComment, $cedit) {

--- a/views/module/comment/cdotanonym.pug
+++ b/views/module/comment/cdotanonym.pug
@@ -22,8 +22,4 @@
             .dotDelimeter ·
             .changed(title="Показать историю изменений") {{='Изменен '+it.fDateIn(new Date(c.lastChanged))}}
             | {{?}}
-            | {{?c.latest}}
-            .dotDelimeter ·
-            .badge.badge-latest Последний комментарий
-            | {{?}}
         .ctext {{=c.txt}}

--- a/views/module/comment/cdotauth.pug
+++ b/views/module/comment/cdotauth.pug
@@ -25,10 +25,6 @@
             .dotDelimeter ·
             .changed(title="Показать историю изменений") {{='Изменен '+it.fDateIn(new Date(c.lastChanged))}}
             | {{?}}
-            | {{?c.latest}}
-            .dotDelimeter ·
-            .badge.badge-latest Последний комментарий
-            | {{?}}
         .ctext {{=c.txt}}
         .cacts
             | {{?it.reply}}


### PR DESCRIPTION
Given users feedback, the idea to have badge is not good as the wording is [associated with the user](https://pastvu.com/news/155?hl=comment-2980605) (on same line with username). Instead we keep the link and highlight latest comment when clicked, similar to links to individual comments. This also resolves content "overloading" issue reported by @paul-k-pastvu 

![image](https://github.com/PastVu/pastvu/assets/329780/24036f67-62c2-4d52-997b-b963b7b51874)
