### PR TITLE
Fix cluster photo retrieval.

### DIFF
--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -723,15 +723,7 @@ Utils.geo = (function () {
      * @returns {number}
      */
     function getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
-        const R = 6371; // Mean radius of the earth in km
-        const dLat = deg2rad(lat2 - lat1); // deg2rad below
-        const dLon = deg2rad(lon2 - lon1);
-        const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        const d = R * c; // Distance in km
-
-        return d;
+        return turf.distance([lon1, lat1], [lon2, lat2], { units: 'kilometers' });
     }
 
     /**

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -203,7 +203,7 @@ export const clusterPhotosAll = async function (params) {
                     Utils.geo.normalizeCoordinates(cluster.g);
 
                     // Link it to photo that will represent cluster.
-                    const dist = Utils.geo.getDistanceFromLatLonInKm(cluster.g[1], cluster.g[0], cluster.geo[1], cluster.geo[0]) * 1000;
+                    const dist = Utils.geo.getDistanceFromLatLonInKm(cluster.g[1], cluster.g[0], cluster.geo[1], cluster.geo[0]) * 2000;
 
                     cluster.p = await Photo.findOne({
                         s: constants.photo.status.PUBLIC,
@@ -320,10 +320,11 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
     }
 
     // Limit searching distance to improve $nearSphere performance.
-    const dist = Utils.geo.getDistanceFromLatLonInKm(g[1], g[0], geoCluster[1], geoCluster[0]) * 1000;
+    const dist = Utils.geo.getDistanceFromLatLonInKm(g[1], g[0], geoCluster[1], geoCluster[0]) * 2000;
     const photo = await Photo.findOne(
         {
-            s: constants.photo.status.PUBLIC, geo: { $nearSphere: { $geometry: { type: 'Point', coordinates: geoCluster }, $maxDistance: dist } },
+            s: constants.photo.status.PUBLIC,
+            geo: { $nearSphere: { $geometry: { type: 'Point', coordinates: geoCluster }, $maxDistance: dist } },
             type: isPainting ? constants.photo.type.PAINTING : constants.photo.type.PHOTO,
         },
         { _id: 0, cid: 1, geo: 1, file: 1, dir: 1, title: 1, year: 1, year2: 1 },
@@ -512,7 +513,7 @@ export async function getBoundsByYear({ geometry, z, year, year2, isPainting }) 
 
 async function getClusterPoster(cluster, yearCriteria, isPainting) {
     // Limit searching distance to improve $nearSphere performance.
-    const dist = Utils.geo.getDistanceFromLatLonInKm(cluster.g[1], cluster.g[0], cluster.geo[1], cluster.geo[0]) * 1000;
+    const dist = Utils.geo.getDistanceFromLatLonInKm(cluster.g[1], cluster.g[0], cluster.geo[1], cluster.geo[0]) * 2000;
 
     cluster.p = await Photo.findOne(
         {

--- a/public/js/lib/Utils.js
+++ b/public/js/lib/Utils.js
@@ -978,27 +978,6 @@ define(['jquery', 'underscore', 'underscore.string', 'lib/geocoordsparser', 'lib
         geo: (function () {
             'use strict';
 
-            /**
-             * Haversine formula to calculate the distance
-             *
-             * @param {number} lat1
-             * @param {number} lon1
-             * @param {number} lat2
-             * @param {number} lon2
-             * @returns {number}
-             */
-            function getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
-                const R = 6371; // Mean radius of the earth in km
-                const dLat = deg2rad(lat2 - lat1); // deg2rad below
-                const dLon = deg2rad(lon2 - lon1);
-                // eslint-disable-next-line max-len
-                const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
-                const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-                const d = R * c; // Distance in km
-
-                return d;
-            }
-
             function deg2rad(deg) {
                 return deg * (Math.PI / 180);
             }
@@ -1086,7 +1065,6 @@ define(['jquery', 'underscore', 'underscore.string', 'lib/geocoordsparser', 'lib
                 deg2rad: deg2rad,
                 geoToPrecision: geoToPrecision,
                 geoToPrecisionRound: geoToPrecisionRound,
-                getDistanceFromLatLonInKm: getDistanceFromLatLonInKm,
                 spinLng: spinLng,
                 latlngToArr: latlngToArr,
                 check: check,


### PR DESCRIPTION
It looks like in some edge cases the photo remains null, distance increase seems fix it (originally this code had no distance limits, but we set it to improve photo search performance in low density areas such as north pole, see #586).

In client lib getDistanceFromLatLonInKm is unused, so removed (instead of making it consistent with server)