### PR TITLE
Respect user login case.

### DIFF
--- a/controllers/__tests__/auth.test.js
+++ b/controllers/__tests__/auth.test.js
@@ -88,13 +88,18 @@ describe('authentication', () => {
             });
 
             it('user login exists', async () => {
-                expect.assertions(1);
+                expect.assertions(2);
 
                 // Register user.
                 await auth.register(data);
 
                 // Change email and register again.
-                const testData = _.defaults({ 'email': 'user2@test.com' }, data);
+                let testData = _.defaults({ 'email': 'user2@test.com' }, data);
+
+                await expect(auth.register(testData)).rejects.toThrow(new AuthenticationError(constants.AUTHENTICATION_USER_EXISTS));
+
+                // Change username to different case and register again.
+                testData = _.defaults({ 'login': 'User1' }, testData);
 
                 await expect(auth.register(testData)).rejects.toThrow(new AuthenticationError(constants.AUTHENTICATION_USER_EXISTS));
             });

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -205,7 +205,7 @@ async function recall({ login }) {
     }
 
     const user = await User.findOne({
-        $or: [{ login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i') }, { email: login.toLowerCase() }],
+        $or: [{ login: new RegExp(`^${_.escapeRegExp(login)}$`) }, { email: login.toLowerCase() }],
     }, null, { lean: true }).exec();
 
     if (!user) {

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -67,7 +67,7 @@ async function giveUser({ login }) {
         user.online = Boolean(userObj);
     } else {
         user = await User.findOne(
-            { login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i'), active: true },
+            { login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true },
             { _id: 0, cid: 0, pass: 0, activatedate: 0, loginAttempts: 0, active: 0, rules: 0 }, { lean: true }
         ).populate([
             {

--- a/models/User.js
+++ b/models/User.js
@@ -153,7 +153,7 @@ registerModel(db => {
     UserScheme.statics.getAuthenticated = async function (login, password) {
         const user = await this.findOne({
             $or: [
-                { login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i') },
+                { login: new RegExp(`^${_.escapeRegExp(login)}$`) },
                 { email: login.toLowerCase() },
             ], active: true, pass: { $ne: 'init' },
         });
@@ -213,7 +213,7 @@ registerModel(db => {
             cb(null, 'Login is not specified');
         }
 
-        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i'), active: true }).select({
+        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).select({
             _id: 0,
             pass: 0,
             activatedate: 0,
@@ -230,7 +230,7 @@ registerModel(db => {
             cb(null, 'Login is not specified');
         }
 
-        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i'), active: true }).exec(cb);
+        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).exec(cb);
     };
 
     UserScheme.statics.getUserAllLoginMail = function (login, cb) {
@@ -242,7 +242,7 @@ registerModel(db => {
             $and: [
                 {
                     $or: [
-                        { login: new RegExp(`^${_.escapeRegExp(login)}$`, 'i') },
+                        { login: new RegExp(`^${_.escapeRegExp(login)}$`) },
                         { email: login.toLowerCase() },
                     ],
                 },


### PR DESCRIPTION
While creating new users with identical username is not possible, we still have some old ones in system that are not possible to retrieve.

Fixes #651