### PR TITLE
Bump mongoose 5.13.20 => 6.13.9 and fix compatibility.

### DIFF
--- a/api.js
+++ b/api.js
@@ -92,7 +92,7 @@ async.waterfall([
         db = mongoose.createConnection() // http://mongoosejs.com/docs/api.html#connection_Connection
             .once('open', openHandler)
             .once('error', errFirstHandler);
-        db.open(moongoUri, { server: { poolSize: moongoPool, auto_reconnect: true }, db: { safe: true } });
+        db.open(moongoUri, { server: { maxPoolSize: moongoPool, auto_reconnect: true }, db: { safe: true } });
 
         function openHandler() {
             const admin = new mongoose.mongo.Admin(db.db);

--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ export async function configure(startStamp) {
 
     await connectDb({
         redis: config.redis,
-        mongo: { uri: config.mongo.connection, poolSize: config.mongo.pool },
+        mongo: { uri: config.mongo.connection, maxPoolSize: config.mongo.pool },
         logger,
     });
 

--- a/config/default.config.js
+++ b/config/default.config.js
@@ -78,7 +78,7 @@ module.exports = {
 
     mongo: {
         connection: 'mongodb://localhost:27017/pastvu',
-        pool: 5, // Number of concurrent connections to DB
+        pool: 10, // Number of concurrent connections to DB
     },
     mongo_api: {
         con: 'mongodb://localhost:27017/pastvu',

--- a/controllers/_session.js
+++ b/controllers/_session.js
@@ -483,7 +483,7 @@ async function popUserRegions(usObj) {
         paths.push({ path: 'mod_regions', select: { _id: 1, cid: 1, parents: 1, title_en: 1, title_local: 1 } });
     }
 
-    await user.populate(paths).execPopulate();
+    await user.populate(paths);
 
     let regionsData = regionController.buildQuery(user.regions);
     let shortRegions = regionController.getShortRegionsParams(regionsData.rhash);
@@ -754,7 +754,7 @@ export const archiveExpiredSessions = async function () {
     const anonQuery = { anonym: { $exists: true }, stamp: { $lte: new Date(start - SESSION_ANON_LIFE) } };
 
     // Simply remove anonymous sessions older then SESSION_ANON_LIFE, there is no point in storing them
-    const { n: countRemovedAnon } = await Session.deleteMany(anonQuery).exec();
+    const { deletedCount: countRemovedAnon } = await Session.deleteMany(anonQuery).exec();
 
     // Move each expired registered user session to sessions_archive
     for await (const session of Session.find(userQuery).limit(5000)) {

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -333,7 +333,7 @@ async function clusterRecalcByPhoto(g, zParam, geoPhotos, yearPhotos, isPainting
     $update.$set.geo = geoCluster;
     $update.$set.y = yCluster;
 
-    const { n: count = 0 } = await ClusterModel.updateOne({ g, z: zParam.z }, $update, { upsert: true }).exec();
+    const { matchedCount: count = 0 } = await ClusterModel.updateOne({ g, z: zParam.z }, $update, { upsert: true }).exec();
 
     return count;
 }

--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -1642,7 +1642,7 @@ async function setNoComments({ cid, type = 'photo', val: nocomments }) {
 }
 
 export async function changeObjCommentsStatus({ obj: { _id: objId, s } }) {
-    const { n: count = 0 } = await Comment.updateMany({ obj: objId }, { $set: { s } }).exec();
+    const { matchedCount: count = 0 } = await Comment.updateMany({ obj: objId }, { $set: { s } }).exec();
 
     return count;
 }
@@ -1698,7 +1698,7 @@ export async function changeObjCommentsVisibility({ obj, hide }) {
 export async function changePhotoCommentsType({ photo: { _id: objId, type } }) {
     const command = { $set: { type } };
 
-    const { n: count = 0 } = await Comment.updateMany({ obj: objId }, command).exec();
+    const { matchedCount: count = 0 } = await Comment.updateMany({ obj: objId }, command).exec();
 
     return { count };
 }

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -258,7 +258,7 @@ async function conveyerClear({ value }) {
     if (value === true) {
         conveyerEnabled = value;
 
-        ({ n: removedCount = 0 } = await PhotoConveyer.deleteMany({ converting: { $exists: false } }).exec());
+        ({ deletedCount: removedCount = 0 } = await PhotoConveyer.deleteMany({ converting: { $exists: false } }).exec());
     }
 
     conveyerLength = await PhotoConveyer.estimatedDocumentCount().exec();
@@ -782,7 +782,7 @@ export async function removePhotos(cids) {
         return 0;
     }
 
-    const { n: removedCount = 0 } = await PhotoConveyer.deleteMany({ cid: { $in: cids } }).exec();
+    const { deletedCount: removedCount = 0 } = await PhotoConveyer.deleteMany({ cid: { $in: cids } }).exec();
 
     conveyerLength -= removedCount;
 

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -2796,7 +2796,7 @@ async function resetIndividualDownloadOrigin({ login, r }) {
         query[`r${region.level}`] = region.cid;
     }
 
-    const { n: updated = 0 } = await Photo.updateMany(
+    const { matchedCount: updated = 0 } = await Photo.updateMany(
         query, { $unset: { disallowDownloadOriginIndividual: 1 } }
     ).exec();
 
@@ -3449,7 +3449,7 @@ const planResetDisplayStat = (function () {
         try {
             logger.info(`Resetting day ${needWeek ? 'and week ' : ''}display statistics...`);
 
-            const { n: count = 0 } = await Photo.updateMany(
+            const { matchedCount: count = 0 } = await Photo.updateMany(
                 { s: { $in: [status.PUBLIC, status.DEACTIVATE, status.REMOVE] } }, { $set: setQuery }
             ).exec();
 

--- a/controllers/subscr.js
+++ b/controllers/subscr.js
@@ -169,7 +169,7 @@ export async function commentAdded(objId, user, stamp = new Date()) {
  */
 export async function commentViewed(objId, user, setInRel) {
     if (setInRel) {
-        const { n: numberAffected = 0 } = await UserObjectRel.updateOne(
+        const { matchedCount: numberAffected = 0 } = await UserObjectRel.updateOne(
             { obj: objId, user: user._id },
             { $unset: { sbscr_noty: 1 }, $set: { sbscr_noty_change: new Date() } },
             { upsert: false }

--- a/controllers/userobjectrel.js
+++ b/controllers/userobjectrel.js
@@ -145,7 +145,7 @@ export async function setCommentView(objId, userId, type = 'photo', stamp = new 
  * @param {string} [type=photo] Object type
  */
 export async function onCommentAdd(objId, userId, type = 'photo') {
-    const { n: count = 0 } = await UserObjectRel.updateMany(
+    const { matchedCount: count = 0 } = await UserObjectRel.updateMany(
         { obj: objId, comments: { $exists: true }, user: { $ne: userId }, type },
         { $inc: { ccount_new: 1 } }
     ).exec();

--- a/downloader.js
+++ b/downloader.js
@@ -292,7 +292,7 @@ export async function configure(startStamp) {
 
     await connectDb({
         redis: config.redis,
-        mongo: { uri: config.mongo.connection, poolSize: config.mongo.pool },
+        mongo: { uri: config.mongo.connection, maxPoolSize: config.mongo.pool },
         logger,
     });
 

--- a/notifier.js
+++ b/notifier.js
@@ -21,7 +21,7 @@ export async function configure(startStamp) {
 
     await connectDb({
         redis: config.redis,
-        mongo: { uri: config.mongo.connection, poolSize: config.mongo.pool },
+        mongo: { uri: config.mongo.connection, maxPoolSize: config.mongo.pool },
         logger,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "migrate-mongo": "8.2.2",
                 "mime": "2.4.4",
                 "moment": "2.29.4",
-                "mongoose": "5.13.20",
+                "mongoose": "6.13.9",
                 "ms": "2.1.2",
                 "mv": "2.1.1",
                 "nodemailer": "6.9.9",
@@ -128,7 +128,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
             "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
@@ -140,7 +139,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
             "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^1.11.1"
@@ -150,7 +148,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
             "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
@@ -167,7 +164,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
             "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
@@ -179,7 +175,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
             "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^1.11.1"
@@ -189,7 +184,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
             "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
@@ -201,7 +195,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.363.0.tgz",
             "integrity": "sha512-tsJzgBSCpna85IVsuS7FBIK9wkSl7fs8TJ/QzapIgu8rKss0ySHVO6TeMVAdw2BvaQl7CxU9c3PosjhLWHu6KQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -249,14 +242,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/client-sso": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
             "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -301,7 +292,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
             "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -346,21 +336,18 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/client-sts": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
             "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -409,14 +396,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.363.0.tgz",
             "integrity": "sha512-5x42JvqEsBUrm6/qdf0WWe4mlmJjPItxamQhRjuOzeQD/BxsA2W5VS/7n0Ws0e27DNhlnUErcIJd+bBy6j1fqA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/client-cognito-identity": "3.363.0",
@@ -433,14 +418,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
             "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -456,14 +439,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
             "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.363.0",
@@ -485,14 +466,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
             "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.363.0",
@@ -515,14 +494,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
             "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -539,14 +516,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
             "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/client-sso": "3.363.0",
@@ -565,14 +540,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
             "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -588,14 +561,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/credential-providers": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.363.0.tgz",
             "integrity": "sha512-hVa1DdYasnLud2EKjDAlDHiV/+H/Zq52chHU00c/R8XwPu1s0kZX3NMmlt0D2HhYqC1mUwtdmE58Jra2POviQQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/client-cognito-identity": "3.363.0",
@@ -622,14 +593,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
             "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -645,14 +614,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
             "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -667,14 +634,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
             "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -690,14 +655,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
             "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.363.0",
@@ -713,14 +676,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-signing": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
             "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -739,14 +700,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
             "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -763,14 +722,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/token-providers": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
             "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "3.363.0",
@@ -788,14 +745,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/types": {
             "version": "3.357.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
             "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -808,14 +763,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/util-endpoints": {
             "version": "3.357.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
             "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -829,14 +782,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/util-locate-window": {
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
             "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -849,14 +800,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
             "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -869,14 +818,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
             "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-sdk/types": "3.357.0",
@@ -900,14 +847,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.3.1"
@@ -917,7 +862,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@babel/cli": {
@@ -3710,7 +3654,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
             "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
@@ -4043,7 +3986,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
             "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4057,14 +3999,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/config-resolver": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
             "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4080,14 +4020,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/credential-provider-imds": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
             "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^1.0.2",
@@ -4104,14 +4042,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/eventstream-codec": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
             "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
@@ -4124,14 +4060,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/fetch-http-handler": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
             "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -4145,14 +4079,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/hash-node": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
             "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4168,14 +4100,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/invalid-dependency": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
             "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4186,14 +4116,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/is-array-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
             "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4206,14 +4134,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/middleware-content-length": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
             "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -4228,14 +4154,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/middleware-endpoint": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
             "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/middleware-serde": "^1.0.2",
@@ -4252,14 +4176,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/middleware-retry": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
             "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -4278,14 +4200,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/middleware-retry/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
             "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -4295,7 +4215,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
             "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4309,14 +4228,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/middleware-stack": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
             "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4329,14 +4246,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/node-config-provider": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
             "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/property-provider": "^1.0.2",
@@ -4352,14 +4267,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/node-http-handler": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
             "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/abort-controller": "^1.0.2",
@@ -4376,14 +4289,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/property-provider": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
             "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4397,14 +4308,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/protocol-http": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
             "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4418,14 +4327,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/querystring-builder": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
             "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4440,14 +4347,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/querystring-parser": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
             "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4461,14 +4366,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/service-error-classification": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
             "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
-            "dev": true,
             "optional": true,
             "engines": {
                 "node": ">=14.0.0"
@@ -4478,7 +4381,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
             "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/types": "^1.1.1",
@@ -4492,14 +4394,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/signature-v4": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
             "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/eventstream-codec": "^1.0.2",
@@ -4519,14 +4419,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/smithy-client": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
             "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/middleware-stack": "^1.0.2",
@@ -4542,14 +4440,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/types": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
             "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4562,14 +4458,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/url-parser": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
             "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^1.0.2",
@@ -4581,14 +4475,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-base64": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
             "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^1.0.2",
@@ -4602,14 +4494,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-body-length-browser": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
             "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4619,14 +4509,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-body-length-node": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
             "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4639,14 +4527,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-buffer-from": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
             "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^1.0.2",
@@ -4660,14 +4546,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-config-provider": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
             "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4680,14 +4564,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
             "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/property-provider": "^1.0.2",
@@ -4703,14 +4585,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-defaults-mode-node": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
             "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/config-resolver": "^1.0.2",
@@ -4728,14 +4608,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-hex-encoding": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
             "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4748,14 +4626,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-middleware": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
             "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4768,14 +4644,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-retry": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
             "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^1.0.3",
@@ -4789,14 +4663,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-stream": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
             "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^1.0.2",
@@ -4816,14 +4688,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-uri-escape": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
             "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "tslib": "^2.5.0"
@@ -4836,14 +4706,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@smithy/util-utf8": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
             "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^1.0.2",
@@ -4857,7 +4725,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/@socket.io/component-emitter": {
@@ -6478,14 +6345,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "node_modules/@types/bson": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-            "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -6581,15 +6440,6 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
         },
-        "node_modules/@types/mongodb": {
-            "version": "3.6.20",
-            "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-            "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-            "dependencies": {
-                "@types/bson": "*",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "20.4.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
@@ -6636,14 +6486,12 @@
         "node_modules/@types/webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
-            "dev": true
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
         },
         "node_modules/@types/whatwg-url": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
             "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/webidl-conversions": "*"
@@ -7534,11 +7382,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/bluebird": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        },
         "node_modules/body-parser": {
             "version": "1.20.3",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -7593,7 +7436,6 @@
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/brace-expansion": {
@@ -9617,7 +9459,6 @@
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
             "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "paypal",
@@ -11764,7 +11605,6 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
             "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "dev": true,
             "dependencies": {
                 "jsbn": "1.1.0",
                 "sprintf-js": "^1.1.3"
@@ -11776,14 +11616,12 @@
         "node_modules/ip-address/node_modules/jsbn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
         },
         "node_modules/ip-address/node_modules/sprintf-js": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -14049,9 +13887,12 @@
             }
         },
         "node_modules/kareem": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-            "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+            "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/keyv": {
             "version": "4.5.2",
@@ -15202,7 +15043,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
             "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-            "dev": true,
             "dependencies": {
                 "@types/whatwg-url": "^8.2.1",
                 "whatwg-url": "^11.0.0"
@@ -15396,53 +15236,42 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "5.13.20",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.20.tgz",
-            "integrity": "sha512-TjGFa/XnJYt+wLmn8y9ssjyO2OhBMeEBtOHb9iJM16EWu2Du6L1Q6zSiEK2ziyYQM8agb4tumNIQFzqbxId7MA==",
+            "version": "6.13.9",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.9.tgz",
+            "integrity": "sha512-x8XpK0SEDJtAtMoOF2U9aGrGXN6kbu01TqhznGLnA4B1oPXNb4Lye0MgmfxF9J2Dva7wf49VOgClk2fuKQYGHw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/bson": "1.x || 4.0.x",
-                "@types/mongodb": "^3.5.27",
-                "bson": "^1.1.4",
-                "kareem": "2.3.2",
-                "mongodb": "3.7.4",
-                "mongoose-legacy-pluralize": "1.0.2",
-                "mpath": "0.8.4",
-                "mquery": "3.2.5",
-                "ms": "2.1.2",
-                "optional-require": "1.0.x",
-                "regexp-clone": "1.0.0",
-                "safe-buffer": "5.2.1",
-                "sift": "13.5.2",
-                "sliced": "1.0.1"
+                "bson": "^4.7.2",
+                "kareem": "2.5.1",
+                "mongodb": "4.17.2",
+                "mpath": "0.9.0",
+                "mquery": "4.0.3",
+                "ms": "2.1.3",
+                "sift": "16.0.1"
             },
             "engines": {
-                "node": ">=4.0.0"
+                "node": ">=12.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mongoose"
             }
         },
-        "node_modules/mongoose-legacy-pluralize": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-            "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-            "peerDependencies": {
-                "mongoose": "*"
-            }
-        },
-        "node_modules/mongoose/node_modules/optional-require": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-            "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
+        "node_modules/mongoose/node_modules/bson": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+            "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+            "dependencies": {
+                "buffer": "^5.6.0"
+            },
             "engines": {
-                "node": ">=4"
+                "node": ">=6.9.0"
             }
         },
-        "node_modules/mongoose/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+        "node_modules/mongoose/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "funding": [
                 {
                     "type": "github",
@@ -15456,43 +15285,52 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/mongoose/node_modules/mongodb": {
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+            "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+            "dependencies": {
+                "bson": "^4.7.2",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=12.9.0"
+            },
+            "optionalDependencies": {
+                "@aws-sdk/credential-providers": "^3.186.0",
+                "@mongodb-js/saslprep": "^1.1.0"
+            }
+        },
+        "node_modules/mongoose/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/mpath": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-            "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+            "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
             "engines": {
                 "node": ">=4.0.0"
             }
         },
         "node_modules/mquery": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-            "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+            "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
             "dependencies": {
-                "bluebird": "3.5.1",
-                "debug": "3.1.0",
-                "regexp-clone": "^1.0.0",
-                "safe-buffer": "5.1.2",
-                "sliced": "1.0.1"
+                "debug": "4.x"
             },
             "engines": {
-                "node": ">=4.0.0"
+                "node": ">=12.0.0"
             }
-        },
-        "node_modules/mquery/node_modules/debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/mquery/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -17058,11 +16896,6 @@
                 "@babel/runtime": "^7.8.4"
             }
         },
-        "node_modules/regexp-clone": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-            "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -17804,9 +17637,9 @@
             }
         },
         "node_modules/sift": {
-            "version": "13.5.2",
-            "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-            "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+            "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
@@ -17881,16 +17714,10 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/sliced": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-            "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
@@ -17958,7 +17785,6 @@
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
             "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-            "dev": true,
             "dependencies": {
                 "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
@@ -18297,7 +18123,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/style-search": {
@@ -18801,7 +18626,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -18825,7 +18649,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/tsscmp": {
             "version": "1.0.6",
@@ -19233,7 +19057,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             }
@@ -19247,7 +19070,6 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-            "dev": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -19498,7 +19320,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
             "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
@@ -19510,7 +19331,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
             "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^1.11.1"
@@ -19520,7 +19340,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
             "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
@@ -19537,7 +19356,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
             "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
@@ -19549,7 +19367,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
             "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^1.11.1"
@@ -19559,7 +19376,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
             "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "^3.222.0",
@@ -19571,7 +19387,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.363.0.tgz",
             "integrity": "sha512-tsJzgBSCpna85IVsuS7FBIK9wkSl7fs8TJ/QzapIgu8rKss0ySHVO6TeMVAdw2BvaQl7CxU9c3PosjhLWHu6KQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -19616,7 +19431,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19625,7 +19439,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
             "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -19667,7 +19480,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19676,7 +19488,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
             "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -19718,7 +19529,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19727,7 +19537,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
             "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
@@ -19773,7 +19582,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19782,7 +19590,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.363.0.tgz",
             "integrity": "sha512-5x42JvqEsBUrm6/qdf0WWe4mlmJjPItxamQhRjuOzeQD/BxsA2W5VS/7n0Ws0e27DNhlnUErcIJd+bBy6j1fqA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/client-cognito-identity": "3.363.0",
@@ -19796,7 +19603,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19805,7 +19611,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
             "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -19818,7 +19623,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19827,7 +19631,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
             "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.363.0",
@@ -19846,7 +19649,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19855,7 +19657,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
             "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.363.0",
@@ -19875,7 +19676,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19884,7 +19684,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
             "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -19898,7 +19697,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19907,7 +19705,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
             "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/client-sso": "3.363.0",
@@ -19923,7 +19720,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19932,7 +19728,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
             "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -19945,7 +19740,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19954,7 +19748,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.363.0.tgz",
             "integrity": "sha512-hVa1DdYasnLud2EKjDAlDHiV/+H/Zq52chHU00c/R8XwPu1s0kZX3NMmlt0D2HhYqC1mUwtdmE58Jra2POviQQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/client-cognito-identity": "3.363.0",
@@ -19978,7 +19771,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -19987,7 +19779,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
             "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20000,7 +19791,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20009,7 +19799,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
             "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20021,7 +19810,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20030,7 +19818,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
             "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20043,7 +19830,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20052,7 +19838,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
             "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.363.0",
@@ -20065,7 +19850,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20074,7 +19858,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
             "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20090,7 +19873,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20099,7 +19881,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
             "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20113,7 +19894,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20122,7 +19902,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
             "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/client-sso-oidc": "3.363.0",
@@ -20137,7 +19916,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20146,7 +19924,6 @@
             "version": "3.357.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
             "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -20156,7 +19933,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20165,7 +19941,6 @@
             "version": "3.357.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
             "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20176,7 +19951,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20185,7 +19959,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
             "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -20195,7 +19968,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20204,7 +19976,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
             "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20217,7 +19988,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20226,7 +19996,6 @@
             "version": "3.363.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
             "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "3.357.0",
@@ -20239,7 +20008,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -20248,7 +20016,6 @@
             "version": "3.259.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.3.1"
@@ -20258,7 +20025,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22221,7 +21987,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
             "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "sparse-bitfield": "^3.0.3"
@@ -22423,7 +22188,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
             "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22434,7 +22198,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22443,7 +22206,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
             "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22456,7 +22218,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22465,7 +22226,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
             "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/node-config-provider": "^1.0.2",
@@ -22479,7 +22239,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22488,7 +22247,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
             "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@aws-crypto/crc32": "3.0.0",
@@ -22501,7 +22259,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22510,7 +22267,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
             "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -22524,7 +22280,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22533,7 +22288,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
             "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22546,7 +22300,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22555,7 +22308,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
             "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22566,7 +22318,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22575,7 +22326,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
             "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -22585,7 +22335,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22594,7 +22343,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
             "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -22606,7 +22354,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22615,7 +22362,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
             "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/middleware-serde": "^1.0.2",
@@ -22629,7 +22375,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22638,7 +22383,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
             "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/protocol-http": "^1.1.1",
@@ -22654,14 +22398,12 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
                     "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22670,7 +22412,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
             "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22681,7 +22422,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22690,7 +22430,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
             "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -22700,7 +22439,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22709,7 +22447,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
             "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/property-provider": "^1.0.2",
@@ -22722,7 +22459,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22731,7 +22467,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
             "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/abort-controller": "^1.0.2",
@@ -22745,7 +22480,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22754,7 +22488,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
             "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22765,7 +22498,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22774,7 +22506,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
             "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22785,7 +22516,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22794,7 +22524,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
             "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22806,7 +22535,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22815,7 +22543,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
             "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22826,7 +22553,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22835,14 +22561,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
             "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
-            "dev": true,
             "optional": true
         },
         "@smithy/shared-ini-file-loader": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
             "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/types": "^1.1.1",
@@ -22853,7 +22577,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22862,7 +22585,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
             "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/eventstream-codec": "^1.0.2",
@@ -22879,7 +22601,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22888,7 +22609,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
             "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/middleware-stack": "^1.0.2",
@@ -22901,7 +22621,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22910,7 +22629,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
             "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -22920,7 +22638,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22929,7 +22646,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
             "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/querystring-parser": "^1.0.2",
@@ -22941,7 +22657,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22950,7 +22665,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
             "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/util-buffer-from": "^1.0.2",
@@ -22961,7 +22675,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22970,7 +22683,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
             "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -22980,7 +22692,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -22989,7 +22700,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
             "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -22999,7 +22709,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23008,7 +22717,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
             "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/is-array-buffer": "^1.0.2",
@@ -23019,7 +22727,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23028,7 +22735,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
             "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -23038,7 +22744,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23047,7 +22752,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
             "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/property-provider": "^1.0.2",
@@ -23060,7 +22764,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23069,7 +22772,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
             "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/config-resolver": "^1.0.2",
@@ -23084,7 +22786,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23093,7 +22794,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
             "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -23103,7 +22803,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23112,7 +22811,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
             "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -23122,7 +22820,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23131,7 +22828,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
             "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/service-error-classification": "^1.0.3",
@@ -23142,7 +22838,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23151,7 +22846,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
             "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/fetch-http-handler": "^1.0.2",
@@ -23168,7 +22862,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23177,7 +22870,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
             "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.5.0"
@@ -23187,7 +22879,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -23196,7 +22887,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
             "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "@smithy/util-buffer-from": "^1.0.2",
@@ -23207,7 +22897,6 @@
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
                     "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-                    "dev": true,
                     "optional": true
                 }
             }
@@ -24509,14 +24198,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "@types/bson": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-            "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/cacheable-request": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -24612,15 +24293,6 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
         },
-        "@types/mongodb": {
-            "version": "3.6.20",
-            "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-            "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-            "requires": {
-                "@types/bson": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/node": {
             "version": "20.4.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
@@ -24667,14 +24339,12 @@
         "@types/webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
-            "dev": true
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
         },
         "@types/whatwg-url": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
             "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-            "dev": true,
             "requires": {
                 "@types/node": "*",
                 "@types/webidl-conversions": "*"
@@ -25350,11 +25020,6 @@
                 }
             }
         },
-        "bluebird": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        },
         "body-parser": {
             "version": "1.20.3",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -25401,7 +25066,6 @@
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "dev": true,
             "optional": true
         },
         "brace-expansion": {
@@ -26887,7 +26551,6 @@
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
             "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "strnum": "^1.0.5"
@@ -28459,7 +28122,6 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
             "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "dev": true,
             "requires": {
                 "jsbn": "1.1.0",
                 "sprintf-js": "^1.1.3"
@@ -28468,14 +28130,12 @@
                 "jsbn": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-                    "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-                    "dev": true
+                    "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
                 },
                 "sprintf-js": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-                    "dev": true
+                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
                 }
             }
         },
@@ -30147,9 +29807,9 @@
             }
         },
         "kareem": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-            "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+            "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
         },
         "keyv": {
             "version": "4.5.2",
@@ -30999,7 +30659,6 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
             "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-            "dev": true,
             "requires": {
                 "@types/whatwg-url": "^8.2.1",
                 "whatwg-url": "^11.0.0"
@@ -31135,74 +30794,66 @@
             }
         },
         "mongoose": {
-            "version": "5.13.20",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.20.tgz",
-            "integrity": "sha512-TjGFa/XnJYt+wLmn8y9ssjyO2OhBMeEBtOHb9iJM16EWu2Du6L1Q6zSiEK2ziyYQM8agb4tumNIQFzqbxId7MA==",
+            "version": "6.13.9",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.9.tgz",
+            "integrity": "sha512-x8XpK0SEDJtAtMoOF2U9aGrGXN6kbu01TqhznGLnA4B1oPXNb4Lye0MgmfxF9J2Dva7wf49VOgClk2fuKQYGHw==",
             "requires": {
-                "@types/bson": "1.x || 4.0.x",
-                "@types/mongodb": "^3.5.27",
-                "bson": "^1.1.4",
-                "kareem": "2.3.2",
-                "mongodb": "3.7.4",
-                "mongoose-legacy-pluralize": "1.0.2",
-                "mpath": "0.8.4",
-                "mquery": "3.2.5",
-                "ms": "2.1.2",
-                "optional-require": "1.0.x",
-                "regexp-clone": "1.0.0",
-                "safe-buffer": "5.2.1",
-                "sift": "13.5.2",
-                "sliced": "1.0.1"
+                "bson": "^4.7.2",
+                "kareem": "2.5.1",
+                "mongodb": "4.17.2",
+                "mpath": "0.9.0",
+                "mquery": "4.0.3",
+                "ms": "2.1.3",
+                "sift": "16.0.1"
             },
             "dependencies": {
-                "optional-require": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-                    "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                }
-            }
-        },
-        "mongoose-legacy-pluralize": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-            "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-            "requires": {}
-        },
-        "mpath": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-            "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
-        },
-        "mquery": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-            "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
-            "requires": {
-                "bluebird": "3.5.1",
-                "debug": "3.1.0",
-                "regexp-clone": "^1.0.0",
-                "safe-buffer": "5.1.2",
-                "sliced": "1.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                "bson": {
+                    "version": "4.7.2",
+                    "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+                    "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
                     "requires": {
-                        "ms": "2.0.0"
+                        "buffer": "^5.6.0"
+                    }
+                },
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                },
+                "mongodb": {
+                    "version": "4.17.2",
+                    "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+                    "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+                    "requires": {
+                        "@aws-sdk/credential-providers": "^3.186.0",
+                        "@mongodb-js/saslprep": "^1.1.0",
+                        "bson": "^4.7.2",
+                        "mongodb-connection-string-url": "^2.6.0",
+                        "socks": "^2.7.1"
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
                 }
+            }
+        },
+        "mpath": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+            "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
+        },
+        "mquery": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+            "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+            "requires": {
+                "debug": "4.x"
             }
         },
         "ms": {
@@ -32352,11 +32003,6 @@
                 "@babel/runtime": "^7.8.4"
             }
         },
-        "regexp-clone": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-            "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-        },
         "regexp.prototype.flags": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -32927,9 +32573,9 @@
             }
         },
         "sift": {
-            "version": "13.5.2",
-            "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-            "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+            "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -32991,16 +32637,10 @@
                 }
             }
         },
-        "sliced": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-            "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
-        },
         "smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
         },
         "socket.io": {
             "version": "4.7.5",
@@ -33046,7 +32686,6 @@
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
             "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-            "dev": true,
             "requires": {
                 "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
@@ -33304,7 +32943,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-            "dev": true,
             "optional": true
         },
         "style-search": {
@@ -33694,7 +33332,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.1"
             }
@@ -33709,7 +33346,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "devOptional": true
         },
         "tsscmp": {
             "version": "1.0.6",
@@ -34010,8 +33647,7 @@
         "webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "dev": true
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "wgs84": {
             "version": "0.0.0",
@@ -34022,7 +33658,6 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-            "dev": true,
             "requires": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "migrate-mongo": "8.2.2",
         "mime": "2.4.4",
         "moment": "2.29.4",
-        "mongoose": "5.13.20",
+        "mongoose": "6.13.9",
         "ms": "2.1.2",
         "mv": "2.1.1",
         "nodemailer": "6.9.9",

--- a/sitemap.js
+++ b/sitemap.js
@@ -63,7 +63,7 @@ const schedule = (function () {
 export async function configure(startStamp) {
     makeDir.sync(sitemapPathAbs);
 
-    await connectDb({ mongo: { uri: config.mongo.connection, poolSize: config.mongo.pool }, logger });
+    await connectDb({ mongo: { uri: config.mongo.connection, maxPoolSize: config.mongo.pool }, logger });
     await regionsReady;
 
     logger.info(`Sitemap generator started up in ${(Date.now() - startStamp) / 1000}s`);

--- a/worker.js
+++ b/worker.js
@@ -27,7 +27,7 @@ export async function configure(startStamp) {
 
     await connectDb({
         redis: config.redis,
-        mongo: { uri: config.mongo.connection, poolSize: config.mongo.pool },
+        mongo: { uri: config.mongo.connection, maxPoolSize: config.mongo.pool },
         logger,
     });
 


### PR DESCRIPTION
Changes according to https://mongoosejs.com/docs/6.x/docs/migrating_to_6.html

Needs testing:
* General functionality
* Behaviour when Mongo instance connection is dropped.
* Migration routines

This patch will allow upgrading Mongo to 7.x (https://mongoosejs.com/docs/compatibility.html)