### PR TITLE
Append image ID after image name in the notification email

### DIFF
--- a/views/mail/notice.pug
+++ b/views/mail/notice.pug
@@ -1,8 +1,11 @@
-mixin noticeLi(arr, path)
+mixin noticeLi(arr, path, isPhoto)
     each val in arr
         - usersLogin = Object.keys(val.brief.users)
         li(style="margin-left: 10px;")
-            a(href=origin + path + val.cid + '?hl=comment-unread&utm_campaign=notification&utm_source=notify_letter&utm_medium=email', target='_blank')= val.title
+            if isPhoto
+                a(href=origin + path + val.cid + '?hl=comment-unread&utm_campaign=notification&utm_source=notify_letter&utm_medium=email', target='_blank')= val.title + ' (#' + val.cid + ')'
+            else
+                a(href=origin + path + val.cid + '?hl=comment-unread&utm_campaign=notification&utm_source=notify_letter&utm_medium=email', target='_blank')= val.title
             div(style="margin-left: 13px;")
                 = val.briefFormat.newest
                 if val.briefFormat.unread
@@ -27,11 +30,11 @@ p На момент отправки данного уведомления в т
 if news.length
     p(style="margin-bottom: 2px;")
         strong Новости:
-    +noticeLi(news, '/news/')
+    +noticeLi(news, '/news/', false)
 if photos.length
     p(style="margin-bottom: 2px;")
         strong Фотографии:
-    +noticeLi(photos, '/p/')
+    +noticeLi(photos, '/p/', true)
 div(style="border-top: 1px solid #eee; border-bottom: 1px solid #fff; margin-top: 1em;")
     p(style="font-size: smaller; margin-top: 0.5em;")
         | Управлять материалами, на которые вы подписаны, можно на странице подписок: <a href='#{origin + '/u/' + user.login + '/subscriptions'}' target='_blank'>#{config.client.host + '/u/' + user.login + '/subscriptions'}</a>


### PR DESCRIPTION
Add Id to email as in https://github.com/PastVu/pastvu/issues/705
![email_photo](https://github.com/user-attachments/assets/16f92085-2f17-45c6-b709-7460b8b3b50e)
Also by default it works for news
![email_news](https://github.com/user-attachments/assets/8e31df5c-ca51-4623-bc55-cfe9fde3a988)
