### PR TITLE
Exclude current point from local cluster

### DIFF
--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -523,7 +523,7 @@ define([
                 this.map.setView(new L.LatLng(P.settings.locDef.lat, P.settings.locDef.lng), P.settings.locDef.z);
             }
 
-            this.markerManager = new MarkerManager(this.map, {
+            this.markerManager = new MarkerManager(this.map, this.point, {
                 enabled: false,
                 openNewTab: this.openNewTab(),
                 isPainting: this.isPainting(),

--- a/public/js/module/photo/photo.js
+++ b/public/js/module/photo/photo.js
@@ -528,7 +528,7 @@ define(['underscore', 'Utils', 'Browser', 'socket!', 'Params', 'knockout', 'knoc
             this.mapVM.setPoint(this.genMapPoint(), this.isPainting());
         },
         genMapPoint: function () {
-            return _.pick(this.p, 'geo', 'year', 'dir', 'title', 'regions');
+            return _.pick(this.p, 'geo', 'year', 'dir', 'title', 'regions', 'cid');
         },
         editGeoChange: function (geo) {
             if (geo) {


### PR DESCRIPTION
Fix for this issue https://github.com/PastVu/pastvu/issues/429
I found how to fix if for local clusters but it will not work for global clusters (with picture).
Looks like there is no an easy option to add a fix for a global cluster because we can only decrease number under a small picture but we may get the current picture as a cluster picture.

Without local cluster (Zoom in)
<img width="1295" height="1138" alt="474480747-0af2a95d-712a-4062-88ca-360124edc941" src="https://github.com/user-attachments/assets/7d2fde5a-f37d-4bb5-b290-c73f508d2283" />


With local cluster (Zoom out)
<img width="1256" height="1008" alt="474480308-c63fa6ae-f84d-4277-ad96-1f34a48606b5" src="https://github.com/user-attachments/assets/0b73e703-ac87-437a-9d0e-afda9a991529" />