### PR TITLE
Remove bottom close button from Share dialog

### DIFF
--- a/public/js/module/photo/photo.js
+++ b/public/js/module/photo/photo.js
@@ -1122,9 +1122,6 @@ define(['underscore', 'Utils', 'Browser', 'socket!', 'Params', 'knockout', 'knoc
                             animateScale: true,
                             curtainClick: { click: self.closeHistoryOrShare, ctx: self },
                             offIcon: { text: 'Закрыть', click: self.closeHistoryOrShare, ctx: self },
-                            btns: [
-                                { css: 'btn-primary', text: 'Закрыть', click: self.closeHistoryOrShare, ctx: self },
-                            ],
                         },
                         callback: function (vm) {
                             self.shareVM = self.childModules[vm.id] = vm;


### PR DESCRIPTION
Removes the bottom "Закрыть" button (`btns`) from the "Share this image" modal while keeping the top-right `offIcon` close button. The dialog can still be dismissed via the offIcon or by clicking outside (curtainClick).

Addresses item 4 of #271.

Generated with [Claude Code](https://claude.ai/code)