### PR TITLE
Migrate to mongoose 7.8.8 

### DIFF
--- a/controllers/connection.js
+++ b/controllers/connection.js
@@ -65,11 +65,6 @@ function init({ mongo, redis, logger = log4js.getLogger('app') }) {
         const { uri, maxPoolSize = 1 } = mongo;
         let connErrorLogLevel = 'error';
 
-        // Set native Promise as mongoose promise provider
-        mongoose.Promise = Promise;
-        // For 5.x compatibility, defaults again to false in 7.x, but 'strict' in 6.x. Remove when migrating to 7.x
-        mongoose.set('strictQuery', false);
-
         connectionPromises.push(new Promise((resolve, reject) => {
             mongoose.connect(uri, {
                 maxPoolSize,
@@ -83,7 +78,7 @@ function init({ mongo, redis, logger = log4js.getLogger('app') }) {
                 // Connection related events are no longer regarded as errors.
                 connErrorLogLevel = 'info';
                 logger.info('MongoDB client is shutting down');
-                db.close(cb);
+                db.close().then(() => cb(), cb);
             });
 
             async function openHandler() {

--- a/controllers/converter.js
+++ b/controllers/converter.js
@@ -237,10 +237,8 @@ async function collectConveyerStat() {
         converted: conveyerConverted,
     });
 
-    st.save(err => {
-        if (err) {
-            logger.error('STPhotoConveyer error.\n ' + err);
-        }
+    st.save().catch(err => {
+        logger.error('STPhotoConveyer error.\n ' + err);
     });
 
     // Update stats.

--- a/controllers/userobjectrel.js
+++ b/controllers/userobjectrel.js
@@ -100,7 +100,7 @@ export function setObjectView(objId, userId, type = 'photo', stamp = new Date())
     return UserObjectRel.findOneAndUpdate(
         { obj: objId, user: userId, type },
         { $set: { view: stamp } },
-        { upsert: true, new: true, lean: true, fields: { _id: 0 } }
+        { upsert: true, returnDocument: 'after', lean: true, fields: { _id: 0 } }
     ).exec();
 }
 

--- a/downloader.js
+++ b/downloader.js
@@ -122,7 +122,7 @@ export async function configure(startStamp) {
                     return responseCode(403, res);
                 }
 
-                const keyEntry = await Download.findOneAndRemove({ key }, { _id: 0, data: 1 }).exec();
+                const keyEntry = await Download.findOneAndDelete({ key }, { _id: 0, data: 1 }).exec();
                 const keyData = _.get(keyEntry, 'data');
                 let filePath = _.get(keyData, 'path');
 

--- a/models/Counter.js
+++ b/models/Counter.js
@@ -16,7 +16,7 @@ registerModel(db => {
 
     CounterSchema.statics.increment = function (counter) {
         return this.findByIdAndUpdate(counter, { $inc: { next: 1 } }, {
-            new: true,
+            returnDocument: 'after',
             upsert: true,
             select: { next: 1 },
         }).exec();
@@ -24,7 +24,7 @@ registerModel(db => {
 
     CounterSchema.statics.incrementBy = function (counter, num) {
         return this.findByIdAndUpdate(counter, { $inc: { next: num } }, {
-            new: true,
+            returnDocument: 'after',
             upsert: true,
             select: { next: 1 },
         }).exec();

--- a/models/User.js
+++ b/models/User.js
@@ -208,37 +208,37 @@ registerModel(db => {
         return pass;
     });
 
-    UserScheme.statics.getUserPublic = function (login, cb) {
+    UserScheme.statics.getUserPublic = function (login) {
         if (!login) {
-            cb(null, 'Login is not specified');
+            return Promise.reject(new Error('Login is not specified'));
         }
 
-        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).select({
+        return this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).select({
             _id: 0,
             pass: 0,
             activatedate: 0,
             rules: 0,
-        }).exec(cb);
+        }).exec();
     };
 
-    UserScheme.statics.getAllPublicUsers = function (cb) {
-        this.find({ active: true }).select({ _id: 0, pass: 0, activatedate: 0, rules: 0 }).exec(cb);
+    UserScheme.statics.getAllPublicUsers = function () {
+        return this.find({ active: true }).select({ _id: 0, pass: 0, activatedate: 0, rules: 0 }).exec();
     };
 
-    UserScheme.statics.getUserAll = function (login, cb) {
+    UserScheme.statics.getUserAll = function (login) {
         if (!login) {
-            cb(null, 'Login is not specified');
+            return Promise.reject(new Error('Login is not specified'));
         }
 
-        this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).exec(cb);
+        return this.findOne({ login: new RegExp(`^${_.escapeRegExp(login)}$`), active: true }).exec();
     };
 
-    UserScheme.statics.getUserAllLoginMail = function (login, cb) {
+    UserScheme.statics.getUserAllLoginMail = function (login) {
         if (!login) {
-            cb(null, 'Login is not specified');
+            return Promise.reject(new Error('Login is not specified'));
         }
 
-        this.findOne({
+        return this.findOne({
             $and: [
                 {
                     $or: [
@@ -248,7 +248,7 @@ registerModel(db => {
                 },
                 { active: true },
             ],
-        }).exec(cb);
+        }).exec();
     };
 
     UserScheme.statics.getUserID = async function (login) {
@@ -267,10 +267,10 @@ registerModel(db => {
                 if (user._id) {
                     result = user._id;
 
-                    if (result._bsontype === 'ObjectID') {
+                    if (result._bsontype === 'ObjectId') {
                         result = result.toString();
                     }
-                } else if (user._bsontype === 'ObjectID') {
+                } else if (user._bsontype === 'ObjectId') {
                     result = user.toString();
                 } else if (user.login) {
                     result = user.login;

--- a/models/_initValues.js
+++ b/models/_initValues.js
@@ -7,51 +7,29 @@ import { Model } from 'mongoose';
 import { Settings } from './Settings';
 import { waitDb } from '../controllers/connection';
 
-Model.saveUpsert = function (findQuery, properties, cb) {
-    this.findOne(findQuery, (err, doc) => {
-        if (err && cb) {
-            cb(err);
+Model.saveUpsert = async function (findQuery, properties) {
+    let doc = await this.findOne(findQuery).exec();
+
+    if (!doc) {
+        doc = new this(findQuery);
+    }
+
+    for (const p in properties) {
+        if (properties.hasOwnProperty(p)) {
+            doc[p] = properties[p];
         }
+    }
 
-        if (!doc) {
-            doc = new this(findQuery);
-        }
-
-        for (const p in properties) {
-            if (properties.hasOwnProperty(p)) {
-                doc[p] = properties[p];
-            }
-        }
-
-        doc.save(!cb ? undefined : (err, doc) => {
-            if (err) {
-                cb(err);
-
-                return;
-            }
-
-            cb(null, doc);
-        });
-    });
+    return doc.save();
 };
 
 waitDb.then(() => {
-    Settings.saveUpsert({ key: 'USE_OSM_API' }, { val: true, desc: 'OSM Active' }, err => {
-        if (err) {
-            console.log('Settings ' + err);
-        }
-    });
-    Settings.saveUpsert({ key: 'USE_YANDEX_API' }, { val: true, desc: 'Yandex Active' }, err => {
-        if (err) {
-            console.log('Settings ' + err);
-        }
-    });
+    Settings.saveUpsert({ key: 'USE_OSM_API' }, { val: true, desc: 'OSM Active' })
+        .catch(err => console.log('Settings ' + err));
+    Settings.saveUpsert({ key: 'USE_YANDEX_API' }, { val: true, desc: 'Yandex Active' })
+        .catch(err => console.log('Settings ' + err));
     Settings.saveUpsert({ key: 'REGISTRATION_ALLOWED' }, {
         val: true,
         desc: 'Open self-registration of new users',
-    }, err => {
-        if (err) {
-            console.log('Settings ' + err);
-        }
-    });
+    }).catch(err => console.log('Settings ' + err));
 });

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -5,32 +5,17 @@
 
 const mongoose = require('mongoose');
 
-mongoose.Query.prototype.paginate = function paginate(page, limit, cb) {
+mongoose.Query.prototype.paginate = async function paginate(page, limit) {
     page = parseInt(page, 10) || 1;
     limit = parseInt(limit, 10) || 10;
 
-    let query = this;
     const model = this.model;
     const skipFrom = page * limit - limit;
+    const query = this.skip(skipFrom).limit(limit);
 
-    query = query.skip(skipFrom).limit(limit);
+    const docs = await query.exec();
+    // eslint-disable-next-line no-underscore-dangle
+    const total = await model.countDocuments(query._conditions).exec();
 
-    if (cb) {
-        query.exec((err, docs) => {
-            if (err) {
-                cb(err, null, null);
-            } else {
-                // eslint-disable-next-line no-underscore-dangle
-                model.countDocuments(query._conditions, (err, total) => {
-                    if (err) {
-                        cb(err, null, null);
-                    } else {
-                        cb(null, docs, total);
-                    }
-                });
-            }
-        });
-    } else {
-        return this;
-    }
+    return { docs, total };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "migrate-mongo": "8.2.3",
                 "mime": "4.1.0",
                 "moment": "2.30.1",
-                "mongoose": "6.13.9",
+                "mongoose": "7.8.8",
                 "ms": "2.1.3",
                 "nodemailer": "8.0.10",
                 "postcss-less": "6.0.0",
@@ -15937,25 +15937,75 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "6.13.9",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.9.tgz",
-            "integrity": "sha512-x8XpK0SEDJtAtMoOF2U9aGrGXN6kbu01TqhznGLnA4B1oPXNb4Lye0MgmfxF9J2Dva7wf49VOgClk2fuKQYGHw==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.8.tgz",
+            "integrity": "sha512-0ntQOglVjlx3d+1sLK45oO5f6GuTgV/zbao0zkpE5S5W40qefpyYQ3Mq9e9nRzR58pp57WkVU+PgM64sVVcxNg==",
             "license": "MIT",
             "dependencies": {
-                "bson": "^4.7.2",
+                "bson": "^5.5.0",
                 "kareem": "2.5.1",
-                "mongodb": "4.17.2",
+                "mongodb": "5.9.2",
                 "mpath": "0.9.0",
-                "mquery": "4.0.3",
+                "mquery": "5.0.0",
                 "ms": "2.1.3",
                 "sift": "16.0.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.20.1"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mongoose"
+            }
+        },
+        "node_modules/mongoose/node_modules/bson": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+            "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14.20.1"
+            }
+        },
+        "node_modules/mongoose/node_modules/mongodb": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+            "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bson": "^5.5.0",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=14.20.1"
+            },
+            "optionalDependencies": {
+                "@mongodb-js/saslprep": "^1.1.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.188.0",
+                "@mongodb-js/zstd": "^1.0.0",
+                "kerberos": "^1.0.0 || ^2.0.0",
+                "mongodb-client-encryption": ">=2.3.0 <3",
+                "snappy": "^7.2.2"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "@mongodb-js/zstd": {
+                    "optional": true
+                },
+                "kerberos": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                }
             }
         },
         "node_modules/mpath": {
@@ -15967,14 +16017,15 @@
             }
         },
         "node_modules/mquery": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-            "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+            "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "4.x"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/ms": {
@@ -30719,17 +30770,35 @@
             }
         },
         "mongoose": {
-            "version": "6.13.9",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.9.tgz",
-            "integrity": "sha512-x8XpK0SEDJtAtMoOF2U9aGrGXN6kbu01TqhznGLnA4B1oPXNb4Lye0MgmfxF9J2Dva7wf49VOgClk2fuKQYGHw==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.8.tgz",
+            "integrity": "sha512-0ntQOglVjlx3d+1sLK45oO5f6GuTgV/zbao0zkpE5S5W40qefpyYQ3Mq9e9nRzR58pp57WkVU+PgM64sVVcxNg==",
             "requires": {
-                "bson": "^4.7.2",
+                "bson": "^5.5.0",
                 "kareem": "2.5.1",
-                "mongodb": "4.17.2",
+                "mongodb": "5.9.2",
                 "mpath": "0.9.0",
-                "mquery": "4.0.3",
+                "mquery": "5.0.0",
                 "ms": "2.1.3",
                 "sift": "16.0.1"
+            },
+            "dependencies": {
+                "bson": {
+                    "version": "5.5.1",
+                    "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+                    "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="
+                },
+                "mongodb": {
+                    "version": "5.9.2",
+                    "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+                    "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+                    "requires": {
+                        "@mongodb-js/saslprep": "^1.1.0",
+                        "bson": "^5.5.0",
+                        "mongodb-connection-string-url": "^2.6.0",
+                        "socks": "^2.7.1"
+                    }
+                }
             }
         },
         "mpath": {
@@ -30738,9 +30807,9 @@
             "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
         },
         "mquery": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-            "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+            "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
             "requires": {
                 "debug": "4.x"
             }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "migrate-mongo": "8.2.3",
         "mime": "4.1.0",
         "moment": "2.30.1",
-        "mongoose": "6.13.9",
+        "mongoose": "7.8.8",
         "ms": "2.1.3",
         "nodemailer": "8.0.10",
         "postcss-less": "6.0.0",


### PR DESCRIPTION
  Dependency (package.json)
  - mongoose: `6.13.9` → `7.8.8`

  Connection (controllers/connection.js)
  - Removed `mongoose.Promise = Promise` (no-op in v7)
  - Removed `mongoose.set('strictQuery', false)` (it's the default in v7)
  - Converted `db.close(cb)` to promise form (callbacks dropped in v7)
  
  Callback removal (v7 dropped callback support)
  - models/User.js — `getUserPublic`, `getAllPublicUsers`, `getUserAll`, `getUserAllLoginMail` now return promises
  - models/_initValues.js — `saveUpsert` converted to async/await; callers use `.catch()`
  - models/pagination.js — paginate returns `{ docs, total }`
  - controllers/converter.js — `st.save(cb)` → `st.save().catch(...)`
  
  Deprecated options replaced
  - `new: true` → `returnDocument: 'after'` in models/Counter.js and controllers/userobjectrel.js
  - `findOneAndRemove` → `findOneAndDelete` in downloader.js
  
  ObjectId casing (v7 changed _bsontype to 'ObjectId')
  - models/User.js — two `_bsontype === 'ObjectID'` comparisons updated
