### PR TITLE
Translate shooting direction labels in dropdown

### DIFF
--- a/public/js/module/photo/fields.js
+++ b/public/js/module/photo/fields.js
@@ -3,7 +3,7 @@
  * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
  */
 
-define(['Browser'], function (Browser) {
+define(['Browser', 'i18n'], function (Browser, i18n) {
     const dirIcons = {
         // Arrows are not unified accross browsers and platforms.
         // The choices we use [default, FF, Mac].
@@ -48,15 +48,15 @@ define(['Browser'], function (Browser) {
         },
         types: ['1', '2'],
         dirVals: {
-            n: 'North',
-            ne: 'Northeast',
-            e: 'East',
-            se: 'Southeast',
-            s: 'South',
-            sw: 'Southwest',
-            w: 'West',
-            nw: 'Northwest',
-            aero: 'Aerial/Satellite',
+            n: i18n('North'),
+            ne: i18n('Northeast'),
+            e: i18n('East'),
+            se: i18n('Southeast'),
+            s: i18n('South'),
+            sw: i18n('Southwest'),
+            w: i18n('West'),
+            nw: i18n('Northwest'),
+            aero: i18n('Aerial/Satellite'),
         },
         dirValsArr: ['w', 'nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'aero'],
         watersign: {

--- a/public/js/module/photo/hist.js
+++ b/public/js/module/photo/hist.js
@@ -244,7 +244,7 @@ define(
                         }
 
                         if (hist.values.dir) {
-                            hist.values.dir = i18n(fields.dirVals[hist.values.dir]);
+                            hist.values.dir = fields.dirVals[hist.values.dir];
                         }
 
                         if (hist.add) {

--- a/views/module/photo/photo.pug
+++ b/views/module/photo/photo.pug
@@ -287,7 +287,7 @@
             span.infoName(data-bind="text: $root.i18n(fields.dir) + ':'")
             span.direction-icon(data-bind="html: getDirIcon(p.dir())")
             | &nbsp;
-            span(data-bind="text: $root.i18n(fields.dirVals[p.dir()])", style="text-transform: lowercase;")
+            span(data-bind="text: fields.dirVals[p.dir()]", style="text-transform: lowercase;")
         // /ko
         //ko if: p.watersignText() && p.watersignTextApplied()
         .info


### PR DESCRIPTION
Pre-translate dirVals at module load so the direction dropdown shows
localized labels (e.g. "Юго-Запад" instead of "Southwest"), and drop
the now-redundant i18n() wraps at the existing consumers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
