### PR TITLE
Add workflow to auto-close stale pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Close stale pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Only handle pull requests, leave issues untouched.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow using `actions/stale@v10` to keep the PR queue tidy.

## Behavior
- Runs daily at 01:30 UTC (also triggerable manually via `workflow_dispatch`).
- A pull request is labeled `stale` after **60 days** of inactivity and closed after a further **7 days** (defaults of `actions/stale@v10`).
- Issues are left untouched (`days-before-issue-stale: -1`, `days-before-issue-close: -1`).
- Any new comment or commit resets the timer and removes the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)