### PR TITLE
Include comments feed state in "Link to current map position"

### DIFF
--- a/public/js/module/main/mainPage.js
+++ b/public/js/module/main/mainPage.js
@@ -75,6 +75,15 @@ define(['underscore', 'Utils', 'Params', 'knockout', 'knockout.mapping', 'm/_mod
             this.$dom.find('#mapContainer').css({ height: P.window.h() - (this.$container.offset().top || 33) - 29 >> 0 });
         },
         isCommentFeedShownByDefault: function () {
+            // A 'comments' query parameter (set via "Link to current map position") takes
+            // precedence, so a shared link reproduces the feed state regardless of the
+            // recipient's stored preference.
+            const commentsParam = globalVM.router.params().comments;
+
+            if (commentsParam !== undefined) {
+                return commentsParam === '1' || commentsParam === 'true';
+            }
+
             const showFeed = Utils.getLocalStorage('page.showCommentsFeed');
 
             return showFeed !== undefined ? showFeed : true;

--- a/public/js/module/map/map.js
+++ b/public/js/module/map/map.js
@@ -845,7 +845,8 @@ define([
                     location.host +
                     '?g=' + center.join(',') + '&z=' + this.map.getZoom() +
                     '&s=' + layerActive.sys.id + '&t=' + layerActive.type.id +
-                    '&type=' + this.type() + y
+                    '&type=' + this.type() + y +
+                    '&comments=' + (this.commentFeedShown() ? '1' : '0')
                 );
                 this.map.on('zoomstart', this.hideLink, this); //Скрываем ссылку при начале зуммирования карты
                 this.linkShow(true);


### PR DESCRIPTION
## Summary

Resolves #737. The "Link to current map position" deep link now persists whether the comments feed is open or closed, so a shared link reproduces the feed state for the recipient — useful for sharing a map without the (largely Cyrillic) comments panel.

## Changes

- **`public/js/module/map/map.js`** — `showLink()` now appends a `comments=1` / `comments=0` query parameter reflecting the current `commentFeedShown()` state. It's encoded unconditionally so the link is deterministic regardless of the recipient's stored preference.
- **`public/js/module/main/mainPage.js`** — `isCommentFeedShownByDefault()` now reads the `comments` query parameter first (driving both the initial collapse state and the `commentFeedShown` observable), falling back to the existing `localStorage` preference when the parameter is absent.

## Behavior

- `comments=0` → feed starts collapsed; `comments=1` → feed starts open.
- No `comments` param → unchanged (falls back to the user's stored preference, default open).
- Manually toggling the feed still updates `localStorage` via the existing Bootstrap `shown/hidden.bs.collapse` handlers; these don't fire on initial render, so opening a `comments=0` link won't clobber the saved preference.

Example: `pastvu.com?g=55.75,37.62&z=17&s=osm&t=kosmosnimki&type=0&comments=0`

Only the main map page is affected; embedded maps don't use `mainPage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)