### PR TITLE
Highlight unpublished (planned) news in admin list

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -290,7 +290,7 @@ async function giveAllNews() {
         { lean: true, sort: { pdate: -1 } }
     ).populate({ path: 'user', select: { _id: 0, login: 1, avatar: 1, disp: 1 } }).exec();
 
-    if (iAm.registered && !news.length) {
+    if (iAm.registered && news.length) {
         // If user is logged in, fill in count of new comments for each news
         await userObjectRelController.fillObjectByRels(news, iAm.user._id, 'news');
         news.forEach(n => delete n._id);

--- a/public/js/lang/i18n.ru.json
+++ b/public/js/lang/i18n.ru.json
@@ -113,6 +113,8 @@
     "Change": "Сменить",
     "New comments": "Новые комментарии",
     "Project news": "Новости проекта",
+    "Not published yet": "Ещё не опубликовано",
+    "Scheduled for publication": "Запланирована к публикации",
     "Open the news comments": "Перейти к комментариям новости",
     "Read more..": "Читать полностью..",
     "News archive": "Архив новостей",

--- a/public/style/diff/newsList.less
+++ b/public/style/diff/newsList.less
@@ -83,6 +83,21 @@
             margin-bottom: 3px;
         }
 
+        .newsPlanned {
+            display: inline-block;
+            margin-right: 6px;
+            padding: 0 6px;
+            font-size: 11px;
+            font-weight: bold;
+            line-height: 17px;
+            text-transform: uppercase;
+            color: #fff;
+            white-space: nowrap;
+            border-radius: 3px;
+            background-color: #e0701a;
+            cursor: help;
+        }
+
         .newsTitle {
             display: inline-block;
             font-weight: bold;
@@ -132,7 +147,12 @@
             }
 
             &.future {
-                background-color: darken(@body-bg, 10%);
+                background-color: darken(@body-bg, 6%);
+                box-shadow: inset 3px 0 0 #e0701a;
+
+                &:hover {
+                    background-color: darken(@body-bg, 2%);
+                }
             }
         }
     }

--- a/views/module/diff/newsList.pug
+++ b/views/module/diff/newsList.pug
@@ -19,6 +19,9 @@
                 // /ko
             .newsBody
                 .newsHead
+                    //ko if: new Date($data.pdate) > new Date()
+                    span.newsPlanned(data-bind="text: $root.i18n('Not published yet'), attr: {title: $root.i18n('Scheduled for publication') + ' ' + moment($data.pdate).format('D MMM YYYY, HH:mm')}")
+                    // /ko
                     a.newsTitle(data-bind="text: $data.title, attr: {href: '/news/' + $data.cid}")
                     .dotDelimeter ·
                     a.authorName(data-bind="text: $data.user.disp, attr: {href: '/u/' + $data.user.login}")


### PR DESCRIPTION
Closes #261.

### Context
Admins already receive scheduled (future-`pdate`) news in the `/admin/news` archive list — that part of #261 was implemented back in 38a4ad863. However, planned items were only distinguished by a barely-visible 10%-darker background, and the issue explicitly asks to **highlight** them. This PR makes that distinction clear.

### Changes
- **"Not published yet" badge** (`views/module/diff/newsList.pug`): rendered only when `pdate > now`, with a tooltip showing the scheduled publication date/time.
- **Clearer row accent** (`public/style/diff/newsList.less`): orange pill badge styling plus an orange inset left-border on the row (replacing the easy-to-miss dark background).
- **Russian translations** (`public/js/lang/i18n.ru.json`): "Ещё не опубликовано" / "Запланирована к публикации". English falls back to the literal keys, per this project's i18n convention.
- **Bug fix** (`controllers/index.js`): `giveAllNews` filled new-comment counts only when the list was empty (`!news.length`), so `ccount_new` never populated in the news archive. Corrected to `news.length`, matching the index-page logic.

### Verification
- `npx eslint` on changed JS — clean
- `npm run i18n:check` — 0 untranslated strings
- Pug template compiles; `i18n.ru.json` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)