### PR TITLE
Keep original source filename in image history (#556)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ app*.zip
 
 # Claude
 .playwright*
-docs/superpowers

--- a/commons/Utils.js
+++ b/commons/Utils.js
@@ -355,6 +355,21 @@ Utils.inputIncomingParse = (function () {
     };
 }());
 
+// Escapes HTML-significant characters so a value is safe to render in an
+// unescaped template context. Uses the same entity mapping as the inline
+// escaper in inputIncomingParse, plus '&'.
+Utils.escapeHtml = function (txt) {
+    'use strict';
+
+    if (txt === undefined || txt === null) {
+        return '';
+    }
+
+    const reversedEscapeChars = { '<': 'lt', '>': 'gt', '"': 'quot', '&': 'amp', "'": '#39' };
+
+    return String(txt).replace(/[<>"'&]/g, m => `&${reversedEscapeChars[m]};`);
+};
+
 Utils.txtHtmlToPlain = function (txt, brShrink) {
     'use strict';
 

--- a/commons/__tests__/Utils.test.js
+++ b/commons/__tests__/Utils.test.js
@@ -98,4 +98,23 @@ describe('utils', () => {
             testInputIncomingParse('', testString, expectedString);
         });
     });
+
+    describe('escapeHtml', () => {
+        it('escapes HTML-significant characters', () => {
+            expect.assertions(1);
+            expect(Utils.escapeHtml('<img src=x onerror="alert(1)">'))
+                .toBe('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+        });
+
+        it('leaves a plain filename untouched', () => {
+            expect.assertions(1);
+            expect(Utils.escapeHtml('IMG_20030714_grandma.jpg')).toBe('IMG_20030714_grandma.jpg');
+        });
+
+        it('returns an empty string for nullish input', () => {
+            expect.assertions(2);
+            expect(Utils.escapeHtml(undefined)).toBe('');
+            expect(Utils.escapeHtml(null)).toBe('');
+        });
+    });
 });

--- a/controllers/__tests__/photo.test.js
+++ b/controllers/__tests__/photo.test.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright: The PastVu contributors.
+ * GNU Affero General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/agpl.txt)
+ */
+
+import { PhotoHistory } from '../../models/Photo';
+import photo from '../photo';
+import testHelpers from '../../tests/testHelpers';
+
+describe('photo', () => {
+    describe('giveObjHist - original filename', () => {
+        const cid = 100500;
+        const filename = 'IMG_20030714_grandma.jpg';
+        let owner;
+
+        beforeEach(async () => {
+            owner = await testHelpers.createUser({ login: 'owner1' });
+
+            // Earliest history entry represents the upload moment with empty
+            // values (this is what saveHistory creates on first edit).
+            await PhotoHistory.create({ cid, user: owner._id, stamp: new Date('2020-01-01'), values: {} });
+
+            // photo.find is reached via this.call; return a photo carrying the
+            // immutable original filename.
+            photo.call = jest.fn(async () => ({ cid, user: owner._id, s: 5, ldate: new Date('2019-12-31'), filename })); //eslint-disable-line jest/prefer-spy-on
+        });
+
+        afterEach(() => {
+            delete photo.call;
+            delete photo.handshake;
+        });
+
+        it('shows original filename to the photo owner', async () => {
+            expect.assertions(2);
+
+            photo.handshake = { usObj: { registered: true, user: owner } };
+
+            const result = await photo.giveObjHist({ cid, fetchId: 1 });
+
+            expect(result.hists).toHaveLength(1);
+            expect(result.hists[0].values.filename).toBe(filename);
+        });
+
+        it('shows original filename to a moderator/admin', async () => {
+            expect.assertions(2);
+
+            const admin = await testHelpers.createUser({ login: 'admin1' });
+
+            photo.handshake = { usObj: { registered: true, isAdmin: true, user: admin } };
+
+            const result = await photo.giveObjHist({ cid, fetchId: 1 });
+
+            expect(result.hists).toHaveLength(1);
+            expect(result.hists[0].values.filename).toBe(filename);
+        });
+
+        it('hides original filename from a non-owner, non-moderator', async () => {
+            expect.assertions(1);
+
+            const stranger = await testHelpers.createUser({ login: 'stranger1' });
+
+            photo.handshake = { usObj: { registered: true, user: stranger } };
+
+            const result = await photo.giveObjHist({ cid, fetchId: 1 });
+            const entriesWithFilename = result.hists.filter(h => h.values).filter(h => 'filename' in h.values);
+
+            expect(entriesWithFilename).toHaveLength(0);
+        });
+
+        it('hides original filename from an unregistered visitor', async () => {
+            expect.assertions(1);
+
+            photo.handshake = { usObj: { registered: false } };
+
+            const result = await photo.giveObjHist({ cid, fetchId: 1 });
+            const entriesWithFilename = result.hists.filter(h => h.values).filter(h => 'filename' in h.values);
+
+            expect(entriesWithFilename).toHaveLength(0);
+        });
+
+        it('shows original filename on the synthetic entry when no history exists yet', async () => {
+            expect.assertions(2);
+
+            await PhotoHistory.deleteMany({ cid });
+
+            photo.handshake = { usObj: { registered: true, user: owner } };
+
+            const result = await photo.giveObjHist({ cid, fetchId: 1 });
+
+            expect(result.hists).toHaveLength(1);
+            expect(result.hists[0].values.filename).toBe(filename);
+        });
+    });
+});

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -617,6 +617,7 @@ async function create({ files }) {
             geo: undefined,
             r2d: [Math.random() * 100, Math.random() * 100],
             title: item.name ? item.name.replace(/(.*)\.[^.]+$/, '$1') : undefined, // Cut off file extension
+            filename: item.name ? Utils.escapeHtml(item.name) : undefined, // Keep original filename (with extension) for history
             frags: undefined,
             watersignText: getUserWaterSign(user),
             convqueue: true,
@@ -3231,6 +3232,23 @@ async function giveObjHist({ cid, fetchId, showDiff }) {
             stamp: photo.ldate,
             values: { s: 0, histmissing: 1 },
         }];
+    }
+
+    // The original upload filename is shown in the earliest (upload) history
+    // entry, sourced from the immutable 'photo.filename' field. It may carry
+    // personal info, so it's only exposed to the photo owner and moderators.
+    if (photo.filename) {
+        const { handshake: { usObj: iAm } } = this;
+        const canSeeFilename = iAm.registered &&
+            (User.isEqual(iAm.user._id, photo.user) || !!permissions.canModerate(photo, iAm));
+
+        if (canSeeFilename) {
+            if (!histories[0].values) {
+                histories[0].values = {};
+            }
+
+            histories[0].values.filename = photo.filename;
+        }
     }
 
     const reasons = new Set();

--- a/docs/superpowers/specs/2026-06-25-source-filename-history-design.md
+++ b/docs/superpowers/specs/2026-06-25-source-filename-history-design.md
@@ -1,0 +1,141 @@
+# Keep source filename in image history — Design
+
+Addresses [issue #556](https://github.com/PastVu/pastvu/issues/556).
+
+## Problem
+
+When a photo is uploaded, its original filename is copied into the editable
+`title` field (with the extension stripped) and then lost the moment the user
+renames the photo. The issue asks to preserve the original filename so a user
+can later recall it — for example, to find the source file on their own disk.
+
+## Goal
+
+Persist the original upload filename and surface it, read-only, in the photo's
+history (change-log) view as part of the upload record, labeled
+"Original filename".
+
+## Non-goals
+
+- No editing of the stored filename.
+- No backfill/migration for photos uploaded before this change.
+- No new UI panel — reuse the existing history view.
+
+## Approach
+
+Store the original filename once as an immutable field on the photo document,
+and **reconstruct** the "Original filename" history line at read time from that
+field. The history view's earliest entry already represents the upload moment
+(it is stamped at the photo's load date `ldate`), so attaching the filename to
+that entry is semantically correct and works for every photo — including those
+never edited (which otherwise have no stored history entry).
+
+This avoids duplicating the value into the `photos_history` collection and
+keeps a single source of truth (`photo.filename`).
+
+## Components & changes
+
+### Backend
+
+1. **`models/Photo.js`** — add `filename: { type: String }` to `PhotoSchema`.
+   Holds the full original upload name including extension. Set only at
+   creation; never edited afterwards.
+
+2. **`controllers/photo.js` → `create()`** (around line 619) — alongside the
+   existing `title`, set `filename` from `item.name` (the original filename
+   captured by `uploader.js` as `file.originalFilename`).
+   - **Sanitize at capture.** The history template renders text values
+     *unescaped* via doT (`{{=value.val}}`), so a crafted filename such as
+     `<img onerror=…>.jpg` would be an injection vector. Neutralize
+     HTML/script-significant characters before storing, consistent with how
+     PastVu handles other incoming user text (e.g. `Utils.inputIncomingParse`
+     / equivalent HTML escaping). The stored value must be safe to render as-is.
+
+3. **`controllers/photo.js` → `giveObjHist()`** — attach `photo.filename` to the
+   earliest history entry's `values.filename` so it renders as a labeled value:
+   - The function already fetches the photo (`photo.find` with `_id: 0`, which
+     returns all fields including `filename`, and leaves `photo.user` as a raw
+     `ObjectId` since `populateUser` is not passed).
+   - Real history exists: set `histories[0].values.filename` (entries are sorted
+     `stamp: 1`, so index 0 is the upload-time entry). This also makes a
+     previously-empty first entry non-empty, so the existing
+     "skip first entry if empty values" guard no longer skips it — exactly the
+     desired upload record.
+   - No stored history yet: the function already synthesizes a placeholder first
+     entry (`{ values: { s: 0, histmissing: 1 } }`); add `filename` to it.
+
+4. **Visibility gate (owner + staff only).** Only inject the filename when the
+   viewer is the photo's owner or can moderate it. In `giveObjHist`, derive
+   `iAm` from `this.handshake.usObj` and compute:
+
+   ```js
+   const canSeeFilename = iAm.registered &&
+       (User.isEqual(iAm.user._id, photo.user) || !!permissions.canModerate(photo, iAm));
+   ```
+
+   `User` is already imported; `permissions` is defined in this module. Inject
+   `filename` only when `canSeeFilename` is true. Other history viewers see the
+   history exactly as before (no filename line).
+
+### Frontend
+
+5. **`public/js/module/photo/fields.js`** — add the label
+   `filename: 'Original filename'` to the exported field map (used as the i18n
+   key for the history value's name).
+
+6. **`public/js/module/photo/hist.js`** — add `'filename'` to the `txtFields`
+   array (line ~16) so the field is picked up into `textValuesArr` and rendered
+   by the existing generic history template.
+
+7. **i18n** — add the Russian translation to
+   `public/js/lang/i18n.ru.json`:
+
+   ```json
+   "Original filename": "Исходное имя файла"
+   ```
+
+   English needs no entry: the i18next config falls back to the key itself
+   (English) when no translation is present, matching the existing pattern for
+   field labels like `"Photo title"` and `"Watermark signature"`. Required so
+   the `i18n-completeness` test (every runtime key must resolve to Russian)
+   passes.
+
+## Data flow
+
+```
+upload → uploader.js (file.originalFilename → FileInfo.name)
+       → photo.create(): store sanitized photo.filename (+ title as today)
+       → user opens history panel
+       → photo.giveObjHist(): if viewer is owner/moderator,
+                              attach photo.filename to the upload-time entry
+       → hist.js / hist.pug render: "Original filename: IMG_…jpg"
+```
+
+## Edge cases
+
+- **Photos uploaded before this change** have no `filename` → nothing injected,
+  history renders unchanged. (Their `title` still holds the original name, so
+  no information was lost for them.)
+- **Never-edited new photos** have no stored history; the synthetic first entry
+  carries the filename, so it still shows for owner/staff.
+- **Non-owner, non-staff viewers** never receive the filename from the server.
+- **Hostile filenames** are sanitized at capture, so unescaped rendering is safe.
+
+## Testing
+
+- `i18n-completeness` and `no-russian-source` tests must stay green (new RU key
+  added; no Cyrillic in source).
+- Add a focused test for `giveObjHist` that verifies: (a) the filename is
+  injected into the first entry for an owner/moderator viewer, and (b) it is
+  absent for an unrelated viewer. Reuse the existing controller test
+  infrastructure (`controllers/__tests__/*`, shared DB setup). If exercising the
+  full upload→create path in tests proves too heavy, cover the injection and
+  gating logic directly and document the manual verification of the upload step.
+- Manual check: upload a photo, rename its title, open history as the owner →
+  see "Original filename" with the original name; open as an unrelated user →
+  filename absent.
+
+## Out of scope / future
+
+- Showing the filename anywhere other than the history view.
+- Backfilling `filename` for historical photos.

--- a/models/Photo.js
+++ b/models/Photo.js
@@ -70,6 +70,8 @@ const PhotoSchema = new Schema({
     path: { type: String, required: true }, // Path to file in filesystem, for example 'i/n/o/ino6k6k6yz.jpg'
     file: { type: String, required: true }, // Url to file, can contain parameters, for example 'i/n/o/ino6k6k6yz.jpg?s=abcdef' to reset users cache
 
+    filename: { type: String }, // Original filename at upload time (with extension), immutable. HTML-escaped.
+
     mime: { type: String }, // like 'image/jpeg'
     format: { type: String }, // like 'JPEG', 'Zip'(png)
     sign: { type: String }, // Signature of original image

--- a/public/js/lang/i18n.ru.json
+++ b/public/js/lang/i18n.ru.json
@@ -426,6 +426,7 @@
     "Individually": "Индивидуально",
     "Add signature to watermark": "Добавлять подпись на вотермарк",
     "Original download": "Скачивание оригинала",
+    "Original filename": "Исходное имя файла",
     "Allow other users to download the original": "Разрешать другим пользователям скачивать оригинал",
     "Permissions": "Полномочия",
     "Regional:": "Региональный:",

--- a/public/js/module/photo/fields.js
+++ b/public/js/module/photo/fields.js
@@ -37,6 +37,7 @@ define(['Browser', 'i18n'], function (Browser, i18n) {
         type: 'Type',
         regions: 'Region',
         title: 'Photo title',
+        filename: 'Original filename',
         desc: 'Description',
         source: 'Source',
         author: 'Author',

--- a/public/js/module/photo/hist.js
+++ b/public/js/module/photo/hist.js
@@ -13,7 +13,7 @@ define(
         let tplRegionsDiff;
         const maxRegionLevel = 5;
         const statusNums = statuses.nums;
-        const txtFields = ['title', 'geo', 'type', 'regions', 'y', 'desc', 'source', 'author', 'address', 'dir', 'watersignText'];
+        const txtFields = ['title', 'filename', 'geo', 'type', 'regions', 'y', 'desc', 'source', 'author', 'address', 'dir', 'watersignText'];
 
         return Cliche.extend({
             pug: pug,


### PR DESCRIPTION
## Summary

Addresses #556. On upload, a photo's original filename was copied into the editable `title` (extension stripped) and lost the moment the user renamed the photo. This persists the original filename and surfaces it, read-only, in the photo's **history** view as an "Original filename" line on the upload record.

Visible to the **photo owner and moderators/admins only** — filenames can carry personal info.

## Changes

- **`models/Photo.js`** — new immutable, HTML-escaped `filename` field on the photo schema.
- **`controllers/photo.js` `create()`** — capture the original filename at upload.
- **`controllers/photo.js` `giveObjHist()`** — attach `photo.filename` to the earliest (upload) history entry, gated to owner/moderators.
- **`commons/Utils.js`** — new `Utils.escapeHtml` helper (the history template renders text values unescaped, so the stored filename is escaped to prevent injection).
- **Frontend** — `fields.js` label, `hist.js` rendered-fields list, and a Russian translation (`"Исходное имя файла"`; EN falls back to the key).
- **`docs/`** — brainstorming design spec (removed the `docs/superpowers` `.gitignore` exclusion).

## Design notes

- **No migration / no history duplication** — the filename lives on the photo doc and the history line is reconstructed at read time, so it also works for never-edited photos and doesn't bloat `photos_history`.
- **Not added to `historyFields`** — it's immutable, never diffed, only displayed.

## Testing

- New `controllers/__tests__/photo.test.js`: owner/admin see the filename; stranger/anonymous don't; synthetic no-history entry also carries it.
- New `Utils.escapeHtml` tests.
- Full suite green (`npm run jest -- --ci`, 163 tests), including the `i18n-completeness` and `no-russian-source` guards. Lint clean.
- Not covered by automated tests: the upload→`create()` filesystem write path (heavy to set up); recommend a manual upload check.

> ⚠️ Pushed to an **experimental** branch as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)