### PR TITLE
Security: Insecure Direct Object Reference in Template Loading

### DIFF
--- a/controllers/tpl.js
+++ b/controllers/tpl.js
@@ -19,7 +19,11 @@ Utils.walkParallel({ dir: path.normalize('./views/module'), onDone: (err, files)
 
 export function loadController(app) {
     app.get('/tpl/{*path}', (req, res) => {
-        const tplPath = req.params.path.join('/');
+        const tplPath = path.normalize(req.params.path.join('/'));
+
+        if (tplPath.startsWith('..') || tplPath.startsWith('/') || tplPath.includes('\0')) {
+            return res.sendStatus(404);
+        }
 
         if (tpls.includes(tplPath)) {
             res.status(200).render('module/' + tplPath);


### PR DESCRIPTION
## Summary

Security: Insecure Direct Object Reference in Template Loading

## Problem

**Severity**: `Medium` | **File**: `controllers/tpl.js:L17`

The `controllers/tpl.js` file loads templates based on user-provided path parameters. While it does check against a whitelist (`tpls.includes(tplPath)`), the path construction uses string concatenation (`'module/' + tplPath`) which could potentially be bypassed if the whitelist check has flaws or if path traversal sequences are somehow processed.

## Solution

Use path.join with proper normalization, ensure strict path validation against an allowlist, and consider using a more robust template resolution mechanism that doesn't rely on user-provided path granularity.

## Changes

- `controllers/tpl.js` (modified)